### PR TITLE
 assetsSources (alternative source path for rnv app assets)

### DIFF
--- a/packages/rnv/src/core/schemaManager/schemaRenativeJson.js
+++ b/packages/rnv/src/core/schemaManager/schemaRenativeJson.js
@@ -376,6 +376,20 @@ const commonProps = {
       'If set to `true` generated js (bundle.js) files will be timestamped and named (bundle-1.0.0.js) every new version. This is useful if you want to enforce invalidate cache agains standard CDN cache policies every new version you deploy',
         examples: [true, false],
     },
+    fontSources: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+      'Array of paths to location of external Fonts',
+        examples: [['{{resolvePackage(react-native-vector-icons)}}/Fonts']],
+    },
+    assetsSources: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+      'Array of paths to alternative external assets. this will take priority over ./appConfigs/base/assets folder on your local project',
+        examples: [['{{resolvePackage(@flexn/template-starter)}}/appConfigs/base/assets']],
+    },
     ...propExt,
 };
 


### PR DESCRIPTION


## Description 

-  Array of paths to alternative external assets. this will take priority over ./appConfigs/base/assets folder on your local project

## Breaking Changes

    
 ## I have tested my changes on:
 
 ReNative project directly:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

New project:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device

Existing Project created with previous version of renative:
 
* [ ] ios simulator
* [ ] ios device
* [ ] android simulator
* [ ] android device
* [ ] web browser
* [ ] tvos simulator
* [ ] tvos device
* [ ] androidtv simulator
* [ ] androidtv device
* [ ] androidwear simulator
* [ ] androidwear device
* [ ] tizen simulator
* [ ] tizen device
* [ ] tizenmobile simulator
* [ ] tizenwatch device
* [ ] webos simulator
* [ ] webos device
* [ ] macos 
* [ ] windows
* [ ] chromecast device
