### PR TITLE
Fix/metro cache while global

### DIFF
--- a/packages/rnv/src/core/engineManager/index.js
+++ b/packages/rnv/src/core/engineManager/index.js
@@ -195,7 +195,7 @@ If you don't want to use this dependency make sure you remove platform which req
             writeRenativeConfigFile(c, c.paths.project.config, c.files.project.config_original);
         }
     }
-    return addedPlugins.length;
+    return Object.keys(addedPlugins).length;
 };
 
 export const loadEnginePackageDeps = async (c, engineConfigs) => {

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -200,8 +200,6 @@
         "react-art": "source:rnv",
         "react-dom": "source:rnv",
         "react-native": "source:rnv",
-        "@react-native-community/cli-platform-ios": "source:rnv",
-        "@react-native-community/cli": "source:rnv",
         "react-native-gesture-handler": "source:rnv"
     },
     "permissions": {


### PR DESCRIPTION
## Description

- Remove rncli from template. Leave it only on engine so on engine config it will install it. Otherwise it will see it present in the template and ignore it and the template config comes later.
- Correct return for `loadEnginePluginDeps`, otherwise no plugins will be installed.
