### PR TITLE
fix: change release scheme name

### DIFF
--- a/packages/template-starter/appConfigs/base/renative.json
+++ b/packages/template-starter/appConfigs/base/renative.json
@@ -158,7 +158,7 @@
                     "bundleIsDev": false,
                     "multipleAPKs": false
                 },
-                "production": {
+                "release": {
                     "signingConfig": "Release",
                     "multipleAPKs": true,
                     "bundleAssets": true,


### PR DESCRIPTION
## Description

-   Describe the nature of the work / fix

## Breaking Changes

-   PRs should not introduce breaking changes to existing functionality
-   if breaking change cannot be avoided it has to be introduced in 2 phases (release cycles of 0.x.0)
    -   `0.x.0` Add new functionality + add `DEPRECATED` warning to existing fuctionality
    -   `0.[x+1].0` Remove deprecated functionality

## I have tested my changes on:

ReNative project directly:

-   [ ] ios simulator
-   [ ] ios device
-   [ ] android simulator
-   [ ] android device
-   [ ] web browser
-   [ ] tvos simulator
-   [ ] tvos device
-   [ ] androidtv simulator
-   [ ] androidtv device
-   [ ] androidwear simulator
-   [ ] androidwear device
-   [ ] tizen simulator
-   [ ] tizen device
-   [ ] tizenmobile simulator
-   [ ] tizenwatch device
-   [ ] webos simulator
-   [ ] webos device
-   [ ] macos
-   [ ] windows
-   [ ] chromecast device

New project:

-   [ ] ios simulator
-   [ ] ios device
-   [ ] android simulator
-   [ ] android device
-   [ ] web browser
-   [ ] tvos simulator
-   [ ] tvos device
-   [ ] androidtv simulator
-   [ ] androidtv device
-   [ ] androidwear simulator
-   [ ] androidwear device
-   [ ] tizen simulator
-   [ ] tizen device
-   [ ] tizenmobile simulator
-   [ ] tizenwatch device
-   [ ] webos simulator
-   [ ] webos device
-   [ ] macos
-   [ ] windows
-   [ ] chromecast device

Existing Project created with previous version of renative:

-   [ ] ios simulator
-   [ ] ios device
-   [ ] android simulator
-   [ ] android device
-   [ ] web browser
-   [ ] tvos simulator
-   [ ] tvos device
-   [ ] androidtv simulator
-   [ ] androidtv device
-   [ ] androidwear simulator
-   [ ] androidwear device
-   [ ] tizen simulator
-   [ ] tizen device
-   [ ] tizenmobile simulator
-   [ ] tizenwatch device
-   [ ] webos simulator
-   [ ] webos device
-   [ ] macos
-   [ ] windows
-   [ ] chromecast device
