### PR TITLE
disable bundler on build

### DIFF
--- a/packages/sdk-apple/src/runner.ts
+++ b/packages/sdk-apple/src/runner.ts
@@ -651,7 +651,9 @@ export const buildXcodeProject = async (c: Context) => {
 
     logDebug('xcodebuild args', args);
 
-    return executeAsync('xcodebuild', { rawCommand: { args } }).then(() => {
+    return executeAsync('xcodebuild', { rawCommand: { args }, env: {
+        RCT_NO_LAUNCH_PACKAGER: true
+    } }).then(() => {
         logSuccess(`Your Build is located in ${chalk().cyan(buildPath)} .`);
     });
 };


### PR DESCRIPTION
## Description

- https://github.com/flexn-io/renative/issues/1127
- disabled bundler launch from xcode step on `rnv build`