### PR TITLE
fix electron export, bump electron version

### DIFF
--- a/packages/engine-rn-electron/package.json
+++ b/packages/engine-rn-electron/package.json
@@ -36,7 +36,7 @@
         "@rnv/sdk-react-native": "1.0.0-canary.1",
         "@rnv/sdk-webpack": "1.0.0-canary.1",
         "better-opn": "1.0.0",
-        "electron": "26.2.4",
+        "electron": "26.3.0",
         "electron-builder": "24.6.4",
         "electron-notarize": "1.2.2"
     },

--- a/packages/engine-rn-electron/src/sdk.ts
+++ b/packages/engine-rn-electron/src/sdk.ts
@@ -216,6 +216,11 @@ const configureProject = (c: RnvContext, exitOnFail?: boolean) =>
             };
         }
 
+        // Fix `Cannot compute electron version from installed node modules - none of the possible electron modules are installed.`
+        // See https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-505307933
+        const enginePkgJson = path.join(engine.rootPath!, 'package.json');
+        const enginePackageJson = readObjectSync(enginePkgJson);
+
         let electronConfig = merge(
             {
                 appId,
@@ -225,6 +230,7 @@ const configureProject = (c: RnvContext, exitOnFail?: boolean) =>
                     output: path.join(platformBuildDir, 'export'),
                 },
                 files: ['!export/*'],
+                electronVersion: enginePackageJson.dependencies.electron,
             },
             macConfig
         );
@@ -235,7 +241,6 @@ const configureProject = (c: RnvContext, exitOnFail?: boolean) =>
             electronConfig = merge(electronConfig, electronConfigExt);
         }
         writeFileSync(electronConfigPath, electronConfig);
-
         resolve();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9852,10 +9852,10 @@ electron-to-chromium@^1.4.526:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.528.tgz#7c900fd73d9d2e8bb0dab0e301f25f0f4776ef2c"
   integrity sha512-UdREXMXzLkREF4jA8t89FQjA8WHI6ssP38PMY4/4KhXFQbtImnghh4GkCgrtiZwLKUKVD2iTVXvDVQjfomEQuA==
 
-electron@26.2.4:
-  version "26.2.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-26.2.4.tgz#36616b2386b083c13ae9188f2d8ccf233c23404a"
-  integrity sha512-weMUSMyDho5E0DPQ3breba3D96IxwNvtYHjMd/4/wNN3BdI5s3+0orNnPVGJFcLhSvKoxuKUqdVonUocBPwlQA==
+electron@26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-26.3.0.tgz#3267773d170310384db76819cf6375bd98b3cc76"
+  integrity sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"


### PR DESCRIPTION
## Description

- https://github.com/flexn-io/renative/issues/1134
- fix issue with electron-builder not finding electron version
- bump electron to latest