### PR TITLE
fix sim not recognized by xcode error

### DIFF
--- a/packages/sdk-apple/src/runner.ts
+++ b/packages/sdk-apple/src/runner.ts
@@ -192,7 +192,7 @@ export const getDeviceToRunOn = async (c: Context) => {
     let devicesArr: AppleDevice[] = [];
     if (device === true) {
         devicesArr = await getAppleDevices(c, false, true);
-    } else if (c.runtime.isTargetTrue) {
+    } else {
         devicesArr = await getAppleDevices(c, true, false);
     }
 


### PR DESCRIPTION
## Description

-   fix "We couldn't find iPhone 14 as a device supported by the current version of your Xcode. Please select another sim" with empty list of choices