### PR TITLE
rnv linking support fixes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,7 +6,7 @@ import Spinner from './ora';
 import Prompt from './prompt';
 import Logger from './logger';
 
-//Using require here to avoid circular dependency issue rnv => @rnv/cli => rnv
+//IMPORTANT: Using require instead of import here to avoid circular dependency issue rnv => @rnv/cli => rnv
 const { executeRnv } = require('rnv');
 
 export const run = () => {

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -165,7 +165,8 @@ export const getCurrentCommand = (excludeDollar = false) => {
         })
         .join(' ');
     const dollar = excludeDollar ? '' : '$ ';
-    return `${dollar}rnv ${output}`;
+    const npx = ctx.paths.IS_NPX_MODE ? 'npx ' : '';
+    return `${dollar}${npx}rnv ${output}`;
 };
 
 export const logToSummary = (v: string, sanitizePaths?: () => string) => {
@@ -189,6 +190,14 @@ export const logSummary = (header = 'SUMMARY') => {
     const ctx = getContext();
 
     if (_jsonOnly) return;
+
+    if (ctx.paths.project.configExists && !ctx.paths.IS_NPX_MODE) {
+        logAndSave(chalk().yellow('You are trying to run global rnv command in your current project.'), true);
+        logAndSave(chalk().yellow('This might lead to unexpected behaviour.'), true);
+        logAndSave(chalk().yellow('Run your rnv command with npx prefix:'), true);
+        logAndSave(chalk().white('npx ' + getCurrentCommand(true)), true);
+    }
+
     let logContent = printIntoBox(`All good as ${ICN_UNICORN} `);
     if (ctx.logMessages && ctx.logMessages.length) {
         logContent = '';
@@ -265,13 +274,13 @@ export const logSummary = (header = 'SUMMARY') => {
     }
 
     if (ctx.timeEnd) {
-        str += printIntoBox(
-            `Executed Time: ${currentChalk.yellow(_msToTime(ctx.timeEnd.getTime() - ctx.timeStart.getTime()))}`
-        );
+        str += printIntoBox(`Executed Time: ${_msToTime(ctx.timeEnd.getTime() - ctx.timeStart.getTime())}`);
     }
 
     str += printIntoBox('');
+
     str += logContent.replace(/\n\s*\n\s*\n/g, '\n\n');
+
     str += printIntoBox('');
     if (ctx.runtime?.platformBuildsProjectPath) {
         str += printIntoBox('Project location:');

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -25,6 +25,18 @@ export const generateContextPaths = (pathObj: RnvContextPathObj, dir: string, co
     pathObj.appConfigsDir = path.join(dir, '..');
 };
 
+const populateLinkingInfo = (ctx: RnvContext) => {
+    //TODO: find better way to deal with linking?
+    ctx.paths.IS_LINKED = path.dirname(ctx.paths.rnv.dir).split(path.sep).pop() === 'packages';
+
+    const npxLoc = '/node_modules/.bin/rnv';
+    const rnvPath = process.argv[1];
+    const rnvExecWorkspaceRoot = rnvPath.split(npxLoc)[0];
+    const isNpxMode = ctx.paths.project.dir.includes(rnvExecWorkspaceRoot);
+
+    ctx.paths.IS_NPX_MODE = isNpxMode;
+};
+
 export const createRnvContext = (ctx?: {
     program?: any;
     process?: any;
@@ -49,8 +61,6 @@ export const createRnvContext = (ctx?: {
 
     c.paths.rnv.dir = ctx?.RNV_HOME_DIR || c.paths.rnv.dir;
 
-    //TODO: find better way to deal with linking
-    c.paths.IS_LINKED = path.dirname(c.paths.rnv.dir).split(path.sep).pop() === 'packages';
     c.paths.CURRENT_DIR = path.resolve('.');
     c.paths.RNV_NODE_MODULES_DIR = path.join(c.paths.rnv.dir, 'node_modules');
 
@@ -79,6 +89,8 @@ export const createRnvContext = (ctx?: {
     }
 
     generateContextPaths(c.paths.project, c.paths.CURRENT_DIR, c.program.configName);
+
+    populateLinkingInfo(c);
 
     c.paths.buildHooks.dir = path.join(c.paths.project.dir, 'buildHooks/src');
     c.paths.buildHooks.dist.dir = path.join(c.paths.project.dir, 'buildHooks/dist');

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -155,6 +155,7 @@ export type RnvContextPaths = {
     GLOBAL_RNV_DIR: string;
     RNV_HOME_DIR: string;
     IS_LINKED: boolean;
+    IS_NPX_MODE: boolean;
     CURRENT_DIR: string;
     RNV_NODE_MODULES_DIR: string;
     //=======

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -27,7 +27,9 @@ export const executeRnvCore = async () => {
         await updateRenativeConfigs(c);
     }
     // for root rnv we simply load all engines upfront
-    if (!c.command && c.paths.project.configExists) {
+    const { configExists } = c.paths.project;
+
+    if (!c.command && configExists) {
         await registerMissingPlatformEngines(c);
     }
     const taskInstance = await findSuitableTask(c);
@@ -35,7 +37,6 @@ export const executeRnvCore = async () => {
     if (c.command && !IGNORE_MISSING_ENGINES_TASKS.includes(c.command)) {
         await registerMissingPlatformEngines(c, taskInstance);
     }
-    // Skip babel.config creation until template check
-    // await checkAndCreateBabelConfig(c);
+
     if (taskInstance?.task) await initializeTask(c, taskInstance?.task);
 };

--- a/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
@@ -1,12 +1,6 @@
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
-
 const path = require('path');
 const os = require('os');
 const { doResolve } = require('@rnv/core');
-
-const _require2 = require('metro-cache');
-
-const { FileStore } = _require2;
 
 const sharedBlacklist = [
     /node_modules\/react\/dist\/.*/,
@@ -36,7 +30,15 @@ function blacklist(additionalBlacklist: RegExp[]) {
 export const withRNVMetro = (config: any) => {
     const projectPath = env.RNV_PROJECT_ROOT || process.cwd();
 
+    const mc = require(require.resolve('@react-native/metro-config', { paths: [projectPath] }));
+
+    const { getDefaultConfig, mergeConfig } = mc;
+
     const watchFolders = [path.resolve(projectPath, 'node_modules')];
+
+    const metroCache = require(require.resolve('metro-cache', { paths: [projectPath] }));
+
+    const { FileStore } = metroCache;
 
     if (env.RNV_IS_MONOREPO === 'true' || env.RNV_IS_MONOREPO === true) {
         const monoRootPath = env.RNV_MONO_ROOT || projectPath;

--- a/packages/engine-rn/package.json
+++ b/packages/engine-rn/package.json
@@ -31,14 +31,14 @@
         "watch": "tsc --watch --preserveWatchOutput"
     },
     "dependencies": {
-        "@react-native/metro-config": "^0.73.1",
         "@rnv/sdk-android": "1.0.0-canary.4",
         "@rnv/sdk-apple": "1.0.0-canary.4",
         "@rnv/sdk-react-native": "1.0.0-canary.4"
     },
     "devDependencies": {},
     "peerDependencies": {
-        "@rnv/core": "^1.0.0-canary.4"
+        "@rnv/core": "^1.0.0-canary.4",
+        "@react-native/metro-config": "^0.73.1"
     },
     "private": false,
     "publishConfig": {

--- a/packages/engine-rn/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn/src/adapters/metroAdapter.ts
@@ -1,4 +1,3 @@
-const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const path = require('path');
 
 const sharedBlacklist = [
@@ -28,6 +27,10 @@ function blacklist(additionalBlacklist: RegExp[]) {
 
 export const withRNVMetro = (config: any) => {
     const projectPath = env.RNV_PROJECT_ROOT || process.cwd();
+
+    const mc = require(require.resolve('@react-native/metro-config', { paths: [projectPath] }));
+
+    const { getDefaultConfig, mergeConfig } = mc;
 
     const watchFolders = [path.resolve(projectPath, 'node_modules')];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3888,71 +3888,6 @@
   resolved "https://registry.npmjs.org/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"
   integrity sha512-KrwSpS1tKI70wuKl68DwJZYEvXktDHdZMG0k2AXD/rJVSlB23/X2CB2cutVR0HwNMJIal9HOUOBB2rVfa6UGtQ==
 
-"@react-native/babel-plugin-codegen@*":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.73.1.tgz#c2a4c661d92fa1e392fcda29a8e4420581570010"
-  integrity sha512-wHUpZ/Gtw9iwKSNsu6rXuXkDtG8mo+/8WcUfocFYXwazLq98QBxXRiJi44gVAS685AusfOPz0p+eNYn68IWN7g==
-  dependencies:
-    "@react-native/codegen" "*"
-
-"@react-native/babel-preset@*":
-  version "0.73.18"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.73.18.tgz#0ff24ba35102d9ac071de8ab10706ccaee5e3e6f"
-  integrity sha512-FzPasmazoX9WZnmwotk6SK9ydiExdqS4Xt5VaukPoY9u8u3AUUODzqjTsWSOxjFD9eRF3Knyg5H8JMDe6pj5wQ==
-  dependencies:
-    "@babel/core" "^7.20.0"
-    "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
-    "@babel/plugin-proposal-class-properties" "^7.18.0"
-    "@babel/plugin-proposal-export-default-from" "^7.0.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.18.0"
-    "@babel/plugin-proposal-numeric-separator" "^7.0.0"
-    "@babel/plugin-proposal-object-rest-spread" "^7.20.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.0.0"
-    "@babel/plugin-proposal-optional-chaining" "^7.20.0"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
-    "@babel/plugin-syntax-export-default-from" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.18.0"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.0.0"
-    "@babel/plugin-transform-arrow-functions" "^7.0.0"
-    "@babel/plugin-transform-async-to-generator" "^7.20.0"
-    "@babel/plugin-transform-block-scoping" "^7.0.0"
-    "@babel/plugin-transform-classes" "^7.0.0"
-    "@babel/plugin-transform-computed-properties" "^7.0.0"
-    "@babel/plugin-transform-destructuring" "^7.20.0"
-    "@babel/plugin-transform-flow-strip-types" "^7.20.0"
-    "@babel/plugin-transform-function-name" "^7.0.0"
-    "@babel/plugin-transform-literals" "^7.0.0"
-    "@babel/plugin-transform-modules-commonjs" "^7.0.0"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.0.0"
-    "@babel/plugin-transform-parameters" "^7.0.0"
-    "@babel/plugin-transform-private-methods" "^7.22.5"
-    "@babel/plugin-transform-private-property-in-object" "^7.22.11"
-    "@babel/plugin-transform-react-display-name" "^7.0.0"
-    "@babel/plugin-transform-react-jsx" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-self" "^7.0.0"
-    "@babel/plugin-transform-react-jsx-source" "^7.0.0"
-    "@babel/plugin-transform-runtime" "^7.0.0"
-    "@babel/plugin-transform-shorthand-properties" "^7.0.0"
-    "@babel/plugin-transform-spread" "^7.0.0"
-    "@babel/plugin-transform-sticky-regex" "^7.0.0"
-    "@babel/plugin-transform-typescript" "^7.5.0"
-    "@babel/plugin-transform-unicode-regex" "^7.0.0"
-    "@babel/template" "^7.0.0"
-    "@react-native/babel-plugin-codegen" "*"
-    babel-plugin-transform-flow-enums "^0.0.2"
-    react-refresh "^0.14.0"
-
-"@react-native/codegen@*":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.73.1.tgz#b081a8b8e4d766e7313fdaaaa7c3f79145dac448"
-  integrity sha512-umgmDWOlfo8y7Ol1dssi5Ade5kR0vGFg4z3A4lC2c1WO7ZU/O446FPLBud+7MV9frqmk64ddnbzrR+U9GN+HoQ==
-  dependencies:
-    "@babel/parser" "^7.20.0"
-    flow-parser "^0.206.0"
-    jscodeshift "^0.14.0"
-    nullthrows "^1.1.1"
-
 "@react-native/codegen@^0.72.6", "@react-native/codegen@^0.72.7":
   version "0.72.7"
   resolved "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.72.7.tgz#b6832ce631ac63143024ea094a6b5480a780e589"
@@ -3972,32 +3907,6 @@
   version "0.72.1"
   resolved "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.72.1.tgz#905343ef0c51256f128256330fccbdb35b922291"
   integrity sha512-cRPZh2rBswFnGt5X5EUEPs0r+pAsXxYsifv/fgy9ZLQokuT52bPH+9xjDR+7TafRua5CttGW83wP4TntRcWNDA==
-
-"@react-native/js-polyfills@^0.73.1":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.73.1.tgz#730b0a7aaab947ae6f8e5aa9d995e788977191ed"
-  integrity sha512-ewMwGcumrilnF87H4jjrnvGZEaPFCAC4ebraEK+CurDDmwST/bIicI4hrOAv+0Z0F7DEK4O4H7r8q9vH7IbN4g==
-
-"@react-native/metro-babel-transformer@^0.73.12":
-  version "0.73.12"
-  resolved "https://registry.yarnpkg.com/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.73.12.tgz#6b9c391285a4e376ea4c7bc42667bed015fdeb7c"
-  integrity sha512-VmxN5aaoOprzDzUR+8c3XYhG0FoMOO6n0ToylCW6EeZCuf5RTY7HWVOhacabGoB1mHrWzJ0wWEsqX+eD4iFxoA==
-  dependencies:
-    "@babel/core" "^7.20.0"
-    "@react-native/babel-preset" "*"
-    babel-preset-fbjs "^3.4.0"
-    hermes-parser "0.15.0"
-    nullthrows "^1.1.1"
-
-"@react-native/metro-config@^0.73.1":
-  version "0.73.1"
-  resolved "https://registry.yarnpkg.com/@react-native/metro-config/-/metro-config-0.73.1.tgz#653da799d126d667bdc4499d1ca17acc011523e7"
-  integrity sha512-bnRcJ2a50XpQ3ZOrNuroGVDQleak6n/JhSxHrNHsiW4gKirVqxGJAryv+7uQg2zeYfGXgMl6ai5dk+gbUz+yxQ==
-  dependencies:
-    "@react-native/js-polyfills" "^0.73.1"
-    "@react-native/metro-babel-transformer" "^0.73.12"
-    metro-config "0.79.1"
-    metro-runtime "0.79.1"
 
 "@react-native/normalize-color@^2.0.0", "@react-native/normalize-color@^2.1.0":
   version "2.1.0"
@@ -11744,24 +11653,12 @@ hermes-estree@0.12.0:
   resolved "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.12.0.tgz#8a289f9aee854854422345e6995a48613bac2ca8"
   integrity sha512-+e8xR6SCen0wyAKrMT3UD0ZCCLymKhRgjEB5sS28rKiFir/fXgLoeRilRUssFCILmGHb+OvHDUlhxs0+IEyvQw==
 
-hermes-estree@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.15.0.tgz#e32f6210ab18c7b705bdcb375f7700f2db15d6ba"
-  integrity sha512-lLYvAd+6BnOqWdnNbP/Q8xfl8LOGw4wVjfrNd9Gt8eoFzhNBRVD95n4l2ksfMVOoxuVyegs85g83KS9QOsxbVQ==
-
 hermes-parser@0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.12.0.tgz#114dc26697cfb41a6302c215b859b74224383773"
   integrity sha512-d4PHnwq6SnDLhYl3LHNHvOg7nQ6rcI7QVil418REYksv0Mh3cEkHDcuhGxNQ3vgnLSLl4QSvDrFCwQNYdpWlzw==
   dependencies:
     hermes-estree "0.12.0"
-
-hermes-parser@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.15.0.tgz#f611a297c2a2dbbfbce8af8543242254f604c382"
-  integrity sha512-Q1uks5rjZlE9RjMMjSUCkGrEIPI5pKJILeCtK1VmTj7U4pf3wVPoo+cxfu+s4cBAPy2JzikIIdCZgBoR6x7U1Q==
-  dependencies:
-    hermes-estree "0.15.0"
 
 hermes-profile-transformer@^0.0.6:
   version "0.0.6"
@@ -13440,7 +13337,7 @@ jest-util@^29.7.0:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-validate@^29.2.1, jest-validate@^29.6.3, jest-validate@^29.7.0:
+jest-validate@^29.2.1, jest-validate@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz#7bf705511c64da591d46b15fce41400d52147d9c"
   integrity sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==
@@ -14786,15 +14683,6 @@ metro-babel-transformer@0.76.8:
     hermes-parser "0.12.0"
     nullthrows "^1.1.1"
 
-metro-babel-transformer@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.79.1.tgz#bb2392227d3db49ffc39b98d8aebe5f7cef46302"
-  integrity sha512-WvE/At9r0LoNoxGgGhULV4H5ieuLs8AHfVUtTpHaOpgE326BwHNiUYaWuCpaM/BTTlajQltK/U1t+MqbbvFG9A==
-  dependencies:
-    "@babel/core" "^7.20.0"
-    hermes-parser "0.15.0"
-    nullthrows "^1.1.1"
-
 metro-cache-key@0.76.7:
   version "0.76.7"
   resolved "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.76.7.tgz#70913f43b92b313096673c37532edd07438cb325"
@@ -14804,11 +14692,6 @@ metro-cache-key@0.76.8:
   version "0.76.8"
   resolved "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.76.8.tgz#8a0a5e991c06f56fcc584acadacb313c312bdc16"
   integrity sha512-buKQ5xentPig9G6T37Ww/R/bC+/V1MA5xU/D8zjnhlelsrPG6w6LtHUS61ID3zZcMZqYaELWk5UIadIdDsaaLw==
-
-metro-cache-key@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.79.1.tgz#80e6f2cd45a3ae04abb6874c75684e91f8c3668e"
-  integrity sha512-/u48AuINgakqYEymRrD6MzKCSYU/JEXrqGX4x6gVHVa99TKPeg5SBi3MIjpZz/tWGpcQHCKItfjLD48YhEJr3Q==
 
 metro-cache@0.76.7:
   version "0.76.7"
@@ -14824,14 +14707,6 @@ metro-cache@0.76.8:
   integrity sha512-QBJSJIVNH7Hc/Yo6br/U/qQDUpiUdRgZ2ZBJmvAbmAKp2XDzsapnMwK/3BGj8JNWJF7OLrqrYHsRsukSbUBpvQ==
   dependencies:
     metro-core "0.76.8"
-    rimraf "^3.0.2"
-
-metro-cache@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.79.1.tgz#197286fb0d3ee6827d91893b50237070c063c157"
-  integrity sha512-uRlo1cYewW9t6KuRED0G/iCnlqPc5Hq+I2VELBiJr4lBYwCz8P1KwcdzgSUpAzcZBcarq6rI9JqVPvV4t6P3YQ==
-  dependencies:
-    metro-core "0.79.1"
     rimraf "^3.0.2"
 
 metro-config@0.76.7:
@@ -14860,19 +14735,6 @@ metro-config@0.76.8:
     metro-core "0.76.8"
     metro-runtime "0.76.8"
 
-metro-config@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.79.1.tgz#34609c582202bc7a2b6712c77352758ffe6a6eed"
-  integrity sha512-gleXbytiPTsO88DDUuaprKQLfaOVfoj6L7yw1u6MRXmQdebK3TmWUajqnLdWDQ/D0+JBWfrkFhLjnWXHsA8Cgw==
-  dependencies:
-    connect "^3.6.5"
-    cosmiconfig "^5.0.5"
-    jest-validate "^29.6.3"
-    metro "0.79.1"
-    metro-cache "0.79.1"
-    metro-core "0.79.1"
-    metro-runtime "0.79.1"
-
 metro-core@0.76.7:
   version "0.76.7"
   resolved "https://registry.npmjs.org/metro-core/-/metro-core-0.76.7.tgz#5d2b8bac2cde801dc22666ad7be1336d1f021b61"
@@ -14888,14 +14750,6 @@ metro-core@0.76.8:
   dependencies:
     lodash.throttle "^4.1.1"
     metro-resolver "0.76.8"
-
-metro-core@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.79.1.tgz#1beed31d6358291d95e42ddb048ed41674f7dea9"
-  integrity sha512-tPlpLLOKT5D5HSFQBrvgU2gupecCA0YcnQQVOByuLjY5JMXUBU7HISHv5gpbJTUt9KlPQ8OhZV/x6ivyXaVSQg==
-  dependencies:
-    lodash.throttle "^4.1.1"
-    metro-resolver "0.79.1"
 
 metro-file-map@0.76.7:
   version "0.76.7"
@@ -14928,25 +14782,6 @@ metro-file-map@0.76.8:
     graceful-fs "^4.2.4"
     invariant "^2.2.4"
     jest-regex-util "^27.0.6"
-    jest-util "^27.2.0"
-    jest-worker "^27.2.0"
-    micromatch "^4.0.4"
-    node-abort-controller "^3.1.1"
-    nullthrows "^1.1.1"
-    walker "^1.0.7"
-  optionalDependencies:
-    fsevents "^2.3.2"
-
-metro-file-map@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.79.1.tgz#c8aa95d1eac0e3fd7a2e54e4d55c6b9a300cfd95"
-  integrity sha512-PpPhfkj1Bj448f+5vZaaImJWFSsf6XveYGdRsfwvskcYlMsFBl4OX1WyGTJCCCzrtIOH5y1V3OADI/HS563sCA==
-  dependencies:
-    anymatch "^3.0.3"
-    debug "^2.2.0"
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.2.4"
-    invariant "^2.2.4"
     jest-util "^27.2.0"
     jest-worker "^27.2.0"
     micromatch "^4.0.4"
@@ -14989,13 +14824,6 @@ metro-minify-terser@0.76.8:
   version "0.76.8"
   resolved "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.76.8.tgz#915ab4d1419257fc6a0b9fa15827b83fe69814bf"
   integrity sha512-Orbvg18qXHCrSj1KbaeSDVYRy/gkro2PC7Fy2tDSH1c9RB4aH8tuMOIXnKJE+1SXxBtjWmQ5Yirwkth2DyyEZA==
-  dependencies:
-    terser "^5.15.0"
-
-metro-minify-terser@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.79.1.tgz#006479abd5eea43525937a3d211af2f4b0c3133f"
-  integrity sha512-69zOvPazJFKE6tHlOF8PQcvXUfoXgeHreVaggjuqnCREMWBjEkTH9jOn8M3oB0JgKmEUBb4bzFr7Oz1kC7Jc3g==
   dependencies:
     terser "^5.15.0"
 
@@ -15135,11 +14963,6 @@ metro-resolver@0.76.8:
   resolved "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.76.8.tgz#0862755b9b84e26853978322464fb37c6fdad76d"
   integrity sha512-KccOqc10vrzS7ZhG2NSnL2dh3uVydarB7nOhjreQ7C4zyWuiW9XpLC4h47KtGQv3Rnv/NDLJYeDqaJ4/+140HQ==
 
-metro-resolver@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.79.1.tgz#80e6e27305eb446188009f54374b642f28f49b65"
-  integrity sha512-hiea5co7c5rhrdD5xYohBq2Sw20Ytzie71raIW9SsXKBKzsS0zAbrwNFW5z71lDUnp719vhobnDXJ+yE7Kq9Gg==
-
 metro-runtime@0.76.7:
   version "0.76.7"
   resolved "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.76.7.tgz#4d75f2dbbcd19a4f01e0d89494e140b0ba8247e4"
@@ -15152,14 +14975,6 @@ metro-runtime@0.76.8:
   version "0.76.8"
   resolved "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.76.8.tgz#74b2d301a2be5f3bbde91b8f1312106f8ffe50c3"
   integrity sha512-XKahvB+iuYJSCr3QqCpROli4B4zASAYpkK+j3a0CJmokxCDNbgyI4Fp88uIL6rNaZfN0Mv35S0b99SdFXIfHjg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    react-refresh "^0.4.0"
-
-metro-runtime@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.79.1.tgz#5598062de56a265b88cdfa735834809552829cf3"
-  integrity sha512-RRBFPjaex8/Q6M+4V0oOYrd4mDG0iNkRMSdT5iojUe9pF24pRmqwG2gm3NBBgh4UAzYPI0NsJ6AB8JTmchfCAg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
@@ -15192,20 +15007,6 @@ metro-source-map@0.76.8:
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-source-map@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.79.1.tgz#6698910de296957207190f6376ef0d54f3b9b4cd"
-  integrity sha512-Rlgld4cfWUFs5NdAErSzWfX9C4eYLPXTBBmhTHaiQEgRb0ydrfhOcofT0gYTHzp6t9lW30IO5wxlzl6gU/nOjA==
-  dependencies:
-    "@babel/traverse" "^7.20.0"
-    "@babel/types" "^7.20.0"
-    invariant "^2.2.4"
-    metro-symbolicate "0.79.1"
-    nullthrows "^1.1.1"
-    ob1 "0.79.1"
-    source-map "^0.5.6"
-    vlq "^1.0.0"
-
 metro-symbolicate@0.76.7:
   version "0.76.7"
   resolved "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.76.7.tgz#1720e6b4ce5676935d7a8a440f25d3f16638e87a"
@@ -15230,18 +15031,6 @@ metro-symbolicate@0.76.8:
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-symbolicate@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.79.1.tgz#29b8f59ac32e2381ec6e44023931b1118b04e4b4"
-  integrity sha512-cB7Yxh5SKs24EsTaONpaEPoFC6H1ya0BeAR1Ety1qeeV/gFmC8YvkwFj9S8sy6whwIf4dM9xLF2iv7Ug78C4JA==
-  dependencies:
-    invariant "^2.2.4"
-    metro-source-map "0.79.1"
-    nullthrows "^1.1.1"
-    source-map "^0.5.6"
-    through2 "^2.0.1"
-    vlq "^1.0.0"
-
 metro-transform-plugins@0.76.7:
   version "0.76.7"
   resolved "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.76.7.tgz#5d5f75371706fbf5166288e43ffd36b5e5bd05bc"
@@ -15257,17 +15046,6 @@ metro-transform-plugins@0.76.8:
   version "0.76.8"
   resolved "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.76.8.tgz#d77c28a6547a8e3b72250f740fcfbd7f5408f8ba"
   integrity sha512-PlkGTQNqS51Bx4vuufSQCdSn2R2rt7korzngo+b5GCkeX5pjinPjnO2kNhQ8l+5bO0iUD/WZ9nsM2PGGKIkWFA==
-  dependencies:
-    "@babel/core" "^7.20.0"
-    "@babel/generator" "^7.20.0"
-    "@babel/template" "^7.0.0"
-    "@babel/traverse" "^7.20.0"
-    nullthrows "^1.1.1"
-
-metro-transform-plugins@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.79.1.tgz#103c6b5562954b6dab6b9c0b73b13742d17fcb87"
-  integrity sha512-kGDpBJGpijC/OVrpngCiyvzrT6sfSPqFOiyEzU02j+8UCmxKCofbdv62nT97dzseR+iWkzFPcCbq8Nc7/CFwwA==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
@@ -15309,23 +15087,6 @@ metro-transform-worker@0.76.8:
     metro-cache-key "0.76.8"
     metro-source-map "0.76.8"
     metro-transform-plugins "0.76.8"
-    nullthrows "^1.1.1"
-
-metro-transform-worker@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.79.1.tgz#1e48f68b532fbae15d6d82270519b9fc6e311598"
-  integrity sha512-WA15xo7EvJgutlhRKldgPTtwOWur4xDO5uQc5e/vZuhGtahcV0b4v2lXp+t3z5gs9DBqajsczce1A+3pY9wcQQ==
-  dependencies:
-    "@babel/core" "^7.20.0"
-    "@babel/generator" "^7.20.0"
-    "@babel/parser" "^7.20.0"
-    "@babel/types" "^7.20.0"
-    metro "0.79.1"
-    metro-babel-transformer "0.79.1"
-    metro-cache "0.79.1"
-    metro-cache-key "0.79.1"
-    metro-source-map "0.79.1"
-    metro-transform-plugins "0.79.1"
     nullthrows "^1.1.1"
 
 metro@0.76.7:
@@ -15425,56 +15186,6 @@ metro@0.76.8:
     metro-symbolicate "0.76.8"
     metro-transform-plugins "0.76.8"
     metro-transform-worker "0.76.8"
-    mime-types "^2.1.27"
-    node-fetch "^2.2.0"
-    nullthrows "^1.1.1"
-    rimraf "^3.0.2"
-    serialize-error "^2.1.0"
-    source-map "^0.5.6"
-    strip-ansi "^6.0.0"
-    throat "^5.0.0"
-    ws "^7.5.1"
-    yargs "^17.6.2"
-
-metro@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.79.1.tgz#e6e2db1d2aca30d88e419d97835572660aba2064"
-  integrity sha512-PDzLQn4fpV4cs6brPi3zSu3zOA3kG+x6algazYGz1FzrOIsIT+L0Hd294+V4xN73EjLrSD5vD5hNsWlBxRk/PA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/core" "^7.20.0"
-    "@babel/generator" "^7.20.0"
-    "@babel/parser" "^7.20.0"
-    "@babel/template" "^7.0.0"
-    "@babel/traverse" "^7.20.0"
-    "@babel/types" "^7.20.0"
-    accepts "^1.3.7"
-    chalk "^4.0.0"
-    ci-info "^2.0.0"
-    connect "^3.6.5"
-    debug "^2.2.0"
-    denodeify "^1.2.1"
-    error-stack-parser "^2.0.6"
-    graceful-fs "^4.2.4"
-    hermes-parser "0.15.0"
-    image-size "^1.0.2"
-    invariant "^2.2.4"
-    jest-worker "^27.2.0"
-    jsc-safe-url "^0.2.2"
-    lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.79.1"
-    metro-cache "0.79.1"
-    metro-cache-key "0.79.1"
-    metro-config "0.79.1"
-    metro-core "0.79.1"
-    metro-file-map "0.79.1"
-    metro-minify-terser "0.79.1"
-    metro-resolver "0.79.1"
-    metro-runtime "0.79.1"
-    metro-source-map "0.79.1"
-    metro-symbolicate "0.79.1"
-    metro-transform-plugins "0.79.1"
-    metro-transform-worker "0.79.1"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -16541,11 +16252,6 @@ ob1@0.76.8:
   version "0.76.8"
   resolved "https://registry.npmjs.org/ob1/-/ob1-0.76.8.tgz#ac4c459465b1c0e2c29aaa527e09fc463d3ffec8"
   integrity sha512-dlBkJJV5M/msj9KYA9upc+nUWVwuOFFTbu28X6kZeGwcuW+JxaHSBZ70SYQnk5M+j5JbNLR6yKHmgW4M5E7X5g==
-
-ob1@0.79.1:
-  version "0.79.1"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.79.1.tgz#11d43712ff2c089d576b13b05b0caeed28389c6b"
-  integrity sha512-Z05NdP9uwS6UWoqNQDqx/VuVBD7rhMBqCB52js9HRct5IsU/lcSC/9Rv4J977wcOrSmaYTXQa2HRkUg4QAIS3g==
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -18680,11 +18386,6 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
-
-react-refresh@^0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
-  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
 react-refresh@^0.4.0:
   version "0.4.3"


### PR DESCRIPTION
## Description

-   Enables to run renative projects with locally bootstrapped renative version of rnv

`rnv link` + `rnv run ...`

## Breaking Changes

none

## I have tested my changes on:

ReNative project directly:

-   [ ] ios simulator
-   [ ] ios device
-   [ ] android simulator
-   [ ] android device
-   [ ] web browser
-   [ ] tvos simulator
-   [ ] tvos device
-   [ ] androidtv simulator
-   [ ] androidtv device
-   [ ] androidwear simulator
-   [ ] androidwear device
-   [ ] tizen simulator
-   [ ] tizen device
-   [ ] tizenmobile simulator
-   [ ] tizenwatch device
-   [ ] webos simulator
-   [ ] webos device
-   [ ] macos
-   [ ] windows
-   [ ] chromecast device

New project:

-   [ ] ios simulator
-   [ ] ios device
-   [ ] android simulator
-   [ ] android device
-   [ ] web browser
-   [ ] tvos simulator
-   [ ] tvos device
-   [ ] androidtv simulator
-   [ ] androidtv device
-   [ ] androidwear simulator
-   [ ] androidwear device
-   [ ] tizen simulator
-   [ ] tizen device
-   [ ] tizenmobile simulator
-   [ ] tizenwatch device
-   [ ] webos simulator
-   [ ] webos device
-   [ ] macos
-   [ ] windows
-   [ ] chromecast device

Existing Project created with previous version of renative:

-   [ ] ios simulator
-   [ ] ios device
-   [ ] android simulator
-   [ ] android device
-   [ ] web browser
-   [ ] tvos simulator
-   [ ] tvos device
-   [ ] androidtv simulator
-   [ ] androidtv device
-   [ ] androidwear simulator
-   [ ] androidwear device
-   [ ] tizen simulator
-   [ ] tizen device
-   [ ] tizenmobile simulator
-   [ ] tizenwatch device
-   [ ] webos simulator
-   [ ] webos device
-   [ ] macos
-   [ ] windows
-   [ ] chromecast device
