### PR TITLE
add rnv as dependency to template

### DIFF
--- a/packages/engine-core/src/tasks/task.rnv.new.ts
+++ b/packages/engine-core/src/tasks/task.rnv.new.ts
@@ -720,9 +720,11 @@ export const taskRnvNew = async (c: RnvContext) => {
     }
     logSuccess(
         `Your project is ready! navigate to project ${chalk().white(`cd ${data.projectName}`)} and run ${chalk().white(
-            'rnv run'
+            'npx rnv run'
         )} to see magic happen!`
     );
+
+    return true;
 };
 
 const findEngineKeyById = (c: RnvContext, id: string) => {

--- a/packages/engine-core/src/tasks/task.rnv.new.ts
+++ b/packages/engine-core/src/tasks/task.rnv.new.ts
@@ -454,6 +454,11 @@ export const taskRnvNew = async (c: RnvContext) => {
         cwd: c.paths.project.dir,
     });
 
+    // Add rnv to package.json
+    await executeAsync(`${isYarnInstalled() ? 'yarn' : 'npm'} add rnv@${c.rnvVersion}`, {
+        cwd: c.paths.project.dir,
+    });
+
     // Check if node_modules folder exists
     if (!fsExistsSync(path.join(c.paths.project.dir, 'node_modules'))) {
         logError(

--- a/packages/template-starter/package.json
+++ b/packages/template-starter/package.json
@@ -81,9 +81,7 @@
         "tsc": "tsc --noEmit --composite false",
         "watch": "tsc --watch --preserveWatchOutput --noEmit"
     },
-    "dependencies": {
-        "rnv": "1.0.0-canary.7"
-    },
+    "dependencies": {},
     "devDependencies": {
         "@flexn/assets-renative-outline": "0.3.2",
         "@flexn/graybox": "0.21.1",
@@ -114,6 +112,7 @@
         "react-native-gesture-handler": "2.13.1",
         "react-native-tvos": "0.72.4-0",
         "react-native-web": "0.19.9",
+        "rnv": "1.0.0-canary.7",
         "xcode": "2.1.0"
     },
     "private": false,

--- a/packages/template-starter/package.json
+++ b/packages/template-starter/package.json
@@ -81,6 +81,9 @@
         "tsc": "tsc --noEmit --composite false",
         "watch": "tsc --watch --preserveWatchOutput --noEmit"
     },
+    "dependencies": {
+        "rnv": "1.0.0-canary.7"
+    },
     "devDependencies": {
         "@flexn/assets-renative-outline": "0.3.2",
         "@flexn/graybox": "0.21.1",
@@ -111,7 +114,6 @@
         "react-native-gesture-handler": "2.13.1",
         "react-native-tvos": "0.72.4-0",
         "react-native-web": "0.19.9",
-        "rnv": "1.0.0-canary.7",
         "xcode": "2.1.0"
     },
     "private": false,
@@ -129,6 +131,5 @@
             "last 1 firefox version",
             "last 1 safari version"
         ]
-    },
-    "dependencies": {}
+    }
 }


### PR DESCRIPTION
## Description
 After `rnv new` CLI says to execute `rnv run`. This will break core since there's gonna be a mismatch and `npx rnv` will not work anyway in this state

Added rnv as a dependency to the template itself, that way `npx rnv` will work out of the box and avoid any core issues. 