### PR TITLE
Web doesn't run on @rnv/template-starter@1.0.0-canary.7

### DIFF
--- a/packages/plugins/pluginTemplates/renative.plugins.json
+++ b/packages/plugins/pluginTemplates/renative.plugins.json
@@ -895,7 +895,7 @@
         },
         "@rnv/renative": {
             "version": "0.37.0-canary.7",
-            "webpack": {
+            "webpackConfig": {
                 "moduleAliases": true,
                 "modulePaths": true
             }

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -134,7 +134,12 @@
         }
     },
     "plugins": {
-        "@rnv/renative": "source:rnv",
+        "@rnv/renative": {
+            "source": "rnv",
+            "webpackConfig": {
+                "modulePaths": true
+            }
+        },
         "react": "source:rnv",
         "react-art": "source:rnv",
         "react-dom": "source:rnv",


### PR DESCRIPTION
## Description

- next does not care about pageExtensions if the package is in node_modules and not transpiled
- make @rnv/renative be transpiled in the template and also plugins, even if not used just yet

## Related issues

- https://github.com/flexn-io/renative/issues/1208

## Npm releases

`1.0.0-feat-bonanza.4`