### PR TITLE
Renative has no indication when assetSources are specified but not found

### DIFF
--- a/packages/core/src/__tests__/projects.test.ts
+++ b/packages/core/src/__tests__/projects.test.ts
@@ -1,0 +1,57 @@
+import { copyAssetsFolder } from '../projects';
+import { getContext } from '../context/provider';
+import { RnvPlatform } from '../types';
+import * as platformsModule from '../platforms';
+import * as commonModule from '../common';
+
+jest.mock('../logger/index.ts', () => {
+    return {
+        logTask: jest.fn(),
+        logWarning: jest.fn(),
+        logInfo: jest.fn(),
+        chalk: () => ({
+            red: jest.fn(),
+            white: jest.fn(),
+        }),
+    };
+});
+
+jest.mock('../platforms', () => ({
+    isPlatformActive: jest.fn() as jest.Mock<boolean>,
+}));
+
+// jest.mock('../common.ts', () => ({
+//     getConfigProp: jest.fn() as jest.Mock<string[]>,
+// }));
+
+// async function throwingFunction() {
+//     throw new Error('This failed');
+// }
+
+describe('copyAssetsFolder', () => {
+    const platform: RnvPlatform = 'web';
+    const c = getContext();
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should exit when platform is not active', async () => {
+        (platformsModule.isPlatformActive as jest.Mock<boolean>).mockReturnValue(false);
+        const result = await copyAssetsFolder(c, platform);
+
+        expect(platformsModule.isPlatformActive).toHaveBeenCalled();
+        expect(result).toBeUndefined();
+    });
+    it('should throws an error when assetSources is declared but not specified', async () => {
+        // (commonModule.getConfigProp as jest.Mock<[]>).mockReturnValue([]);
+        const spy = jest.spyOn(commonModule, 'getConfigProp').mockReturnValueOnce('web').mockReturnValueOnce([]);
+        expect(spy).toHaveBeenCalledWith(c, platform, 'assetFolderPlatform');
+        expect(spy).toHaveBeenCalledWith(c, platform, 'assetSources');
+
+        // await expect(throwingFunction()).rejects.toThrow();
+        await expect(copyAssetsFolder(c, platform)).rejects.toThrowError(`AssetSources is declared but not specified.`);
+        expect(spy).toHaveBeenCalledTimes(2);
+        spy.mockRestore();
+    });
+});

--- a/packages/core/src/__tests__/projects.test.ts
+++ b/packages/core/src/__tests__/projects.test.ts
@@ -9,9 +9,12 @@ jest.mock('../logger/index.ts', () => {
         logTask: jest.fn(),
         logWarning: jest.fn(),
         logInfo: jest.fn(),
+        logError: jest.fn(),
+
         chalk: () => ({
             red: jest.fn(),
             white: jest.fn(),
+            blue: jest.fn(),
         }),
     };
 });
@@ -19,14 +22,6 @@ jest.mock('../logger/index.ts', () => {
 jest.mock('../platforms', () => ({
     isPlatformActive: jest.fn() as jest.Mock<boolean>,
 }));
-
-// jest.mock('../common.ts', () => ({
-//     getConfigProp: jest.fn() as jest.Mock<string[]>,
-// }));
-
-// async function throwingFunction() {
-//     throw new Error('This failed');
-// }
 
 describe('copyAssetsFolder', () => {
     const platform: RnvPlatform = 'web';
@@ -44,13 +39,16 @@ describe('copyAssetsFolder', () => {
         expect(result).toBeUndefined();
     });
     it('should throws an error when assetSources is declared but not specified', async () => {
-        // (commonModule.getConfigProp as jest.Mock<[]>).mockReturnValue([]);
+        //GIVEN
         const spy = jest.spyOn(commonModule, 'getConfigProp').mockReturnValueOnce('web').mockReturnValueOnce([]);
+        (platformsModule.isPlatformActive as jest.Mock<boolean>).mockReturnValue(true);
+        //WHEN
+        await expect(copyAssetsFolder(c, platform)).rejects.toMatch(`AssetSources is declared but not specified.`);
+
+        //THEN
         expect(spy).toHaveBeenCalledWith(c, platform, 'assetFolderPlatform');
         expect(spy).toHaveBeenCalledWith(c, platform, 'assetSources');
 
-        // await expect(throwingFunction()).rejects.toThrow();
-        await expect(copyAssetsFolder(c, platform)).rejects.toThrowError(`AssetSources is declared but not specified.`);
         expect(spy).toHaveBeenCalledTimes(2);
         spy.mockRestore();
     });

--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -449,6 +449,8 @@ export const copyAssetsFolder = async (
     const tsPathsConfig = getTimestampPathsConfig(c, platform);
 
     const assetSources = getConfigProp(c, platform, 'assetSources') || [];
+    if (!assetSources.length)
+        throw new Error(`AssetSources is declared but not specified.Check ${chalk().blue(c.paths.appConfig.dir)} .`);
 
     const validAssetSources: Array<string> = [];
     if (assetFolderPlatform) {
@@ -456,6 +458,8 @@ export const copyAssetsFolder = async (
             const assetsPath = path.join(_resolvePackage(c, v), assetFolderPlatform);
             if (fsExistsSync(assetsPath)) {
                 validAssetSources.push(assetsPath);
+            } else {
+                throw new Error(`AssetSources is specified as  ${chalk().red(v)}. But it was not found.`);
             }
         });
     }

--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -433,7 +433,6 @@ export const copyAssetsFolder = async (
     customFn?: (c: RnvContext, platform: RnvPlatform) => void
 ) => {
     logTask('copyAssetsFolder');
-
     if (!isPlatformActive(c, platform)) return;
 
     const assetFolderPlatform = (getConfigProp(c, platform, 'assetFolderPlatform') || platform) as RnvPlatform;
@@ -449,8 +448,11 @@ export const copyAssetsFolder = async (
     const tsPathsConfig = getTimestampPathsConfig(c, platform);
 
     const assetSources = getConfigProp(c, platform, 'assetSources') || [];
-    if (!assetSources.length)
-        throw new Error(`AssetSources is declared but not specified.Check ${chalk().blue(c.paths.appConfig.dir)} .`);
+    if (!assetSources.length) {
+        return Promise.reject(
+            `AssetSources is declared but not specified.Check ${chalk().blue(c.paths.appConfig.dir)} .`
+        );
+    }
 
     const validAssetSources: Array<string> = [];
     if (assetFolderPlatform) {
@@ -459,7 +461,7 @@ export const copyAssetsFolder = async (
             if (fsExistsSync(assetsPath)) {
                 validAssetSources.push(assetsPath);
             } else {
-                throw new Error(`AssetSources is specified as  ${chalk().red(v)}. But it was not found.`);
+                return Promise.reject(`AssetSources is specified as  ${chalk().red(v)}. But it was not found.`);
             }
         });
     }

--- a/packages/sdk-utils/src/__tests__/index.test.ts
+++ b/packages/sdk-utils/src/__tests__/index.test.ts
@@ -1,9 +1,54 @@
-// import runner from '../index';
+import { getValidLocalhost, getDevServerHost } from '../';
+import { DEFAULTS, createRnvApi, createRnvContext, getContext } from '@rnv/core';
 
-// console.log = jest.fn();
+describe('getValidLocalhost', () => {
+    it('should return passed localhost when value is falsy', () => {
+        const result = getValidLocalhost('', 'localhost');
+        expect(result).toBe('localhost');
+    });
 
-describe('test add function', () => {
-    it('should return 15 for add(10,5)', () => {
-        expect(true).toEqual(true);
+    it('should return localhost for known values', () => {
+        const values = ['localhost', '0.0.0.0', '127.0.0.1'];
+        const localhost = 'localhost';
+        values.forEach((value) => {
+            const result = getValidLocalhost(value, localhost);
+            expect(result).toBe(localhost);
+        });
+    });
+
+    it('should return passed value for the rest cases', () => {
+        const result = getValidLocalhost('unknownValue', 'localhost');
+        expect(result).toBe('unknownValue');
+    });
+});
+
+describe('getDevServerHost', () => {
+    beforeAll(() => {
+        createRnvContext();
+        createRnvApi();
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('should return DEFAULTS.devServerHost when devServerHost is not defined', () => {
+        const c = getContext();
+        c.runtime.localhost = '0.0.0.0 ';
+
+        jest.spyOn(require('@rnv/core'), 'getConfigProp').mockReturnValue(undefined);
+
+        const result = getDevServerHost(c);
+
+        expect(result).toBe(DEFAULTS.devServerHost);
+    });
+    it('should return a fixed devServerHost when defined and equal to one of the known values', () => {
+        const c = getContext();
+        c.runtime.localhost = '0.0.0.0';
+
+        jest.spyOn(require('@rnv/core'), 'getConfigProp').mockReturnValue('localhost');
+        jest.spyOn(require('../'), 'getValidLocalhost').mockReturnValue('0.0.0.0');
+
+        const result = getDevServerHost(c);
+
+        expect(result).toBe('0.0.0.0');
     });
 });


### PR DESCRIPTION
## Description

- added the throwing an error if assetSources are specified but not found
- added tests for packages/sdk-utils
- added tests for the copyAssetsFolder function

## Related issues

- https://github.com/flexn-io/renative/issues/1066

## Npm releases

n/a