### PR TITLE
Renative is missing configuration for hermes

### DIFF
--- a/packages/engine-rn-tvos/templates/platforms/tvos/Podfile
+++ b/packages/engine-rn-tvos/templates/platforms/tvos/Podfile
@@ -26,7 +26,7 @@ target 'RNVApp' do
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.
-    :hermes_enabled => flags[:hermes_enabled],
+    :hermes_enabled => {{HERMES_ENABLED}},
     :fabric_enabled => flags[:fabric_enabled],
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/../.."
@@ -49,7 +49,7 @@ target 'RNVApp-tvOS' do
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.
-    :hermes_enabled => flags[:hermes_enabled],
+    :hermes_enabled => {{HERMES_ENABLED}},
     :fabric_enabled => flags[:fabric_enabled],
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/../.."

--- a/packages/engine-rn/templates/platforms/ios/Podfile
+++ b/packages/engine-rn/templates/platforms/ios/Podfile
@@ -47,7 +47,7 @@ target 'RNVApp' do
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.
-    :hermes_enabled => flags[:hermes_enabled],
+    :hermes_enabled => {{HERMES_ENABLED}},
     :fabric_enabled => flags[:fabric_enabled],
     # Enables Flipper.
     #

--- a/packages/engine-rn/templates/platforms/ios/RNVApp.xcodeproj/project.pbxproj
+++ b/packages/engine-rn/templates/platforms/ios/RNVApp.xcodeproj/project.pbxproj
@@ -416,14 +416,12 @@
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-DoubleConversion/double-conversion.framework/double-conversion",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-Glog/glog.framework/glog",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/double-conversion.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -519,14 +517,12 @@
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-DoubleConversion/double-conversion.framework/double-conversion",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-Glog/glog.framework/glog",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/double-conversion.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/sdk-apple/src/podfileParser.ts
+++ b/packages/sdk-apple/src/podfileParser.ts
@@ -27,6 +27,8 @@ export const parsePodFile = async (c: Context, platform: RnvPlatform) => {
     logTask('parsePodFile');
 
     const appFolder = getAppFolder(c);
+    const useHermes = getConfigProp(c, c.platform, 'reactNativeEngine') === 'hermes';
+
     let pluginInject = '';
 
     // PLUGINS
@@ -187,6 +189,10 @@ export const parsePodFile = async (c: Context, platform: RnvPlatform) => {
         {
             pattern: '{{PLUGIN_NODE_REQUIRE}}',
             override: c.payload.pluginConfigiOS.podfileNodeRequire || '',
+        },
+        {
+            pattern: '{{HERMES_ENABLED}}',
+            override: `${useHermes}`,
         },
     ];
 

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -110,9 +110,7 @@
             "minSdkVersion": 21,
             "extendPlatform": "android",
             "engine": "engine-rn-tvos",
-            "includedPermissions": [
-                "INTERNET"
-            ]
+            "includedPermissions": ["INTERNET"]
         },
         "web": {
             "engine": "engine-rn-next"
@@ -120,7 +118,8 @@
         "tvos": {
             "engine": "engine-rn-tvos",
             "schemeTarget": "RNVApp-tvOS",
-            "deploymentTarget": "14.0"
+            "deploymentTarget": "14.0",
+            "reactNativeEngine": "hermes"
         },
         "macos": {
             "engine": "engine-rn-electron"
@@ -130,7 +129,8 @@
         },
         "ios": {
             "engine": "engine-rn",
-            "deploymentTarget": "14.0"
+            "deploymentTarget": "14.0",
+            "reactNativeEngine": "hermes"
         }
     },
     "plugins": {


### PR DESCRIPTION
## Description

- Add configuration for hermes
even if I disable hermes [these paths](https://github.com/flexn-io/renative/blob/2a19c5bdeb1e630f2f79cb3a998f31d93971093b/packages/engine-rn/templates/platforms/ios/RNVApp.xcodeproj/project.pbxproj#L419) still remains in pbxproj, don’t know what impact it has, but at least original rn or expo removing it based on configuration. so FYI
[project.pbxproj](https://github.com/flexn-io/renative/blob/2a19c5bdeb1e630f2f79cb3a998f31d93971093b/packages/engine-rn/templates/platforms/ios/RNVApp.xcodeproj/project.pbxproj)
               
```
 "${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
```

## Related issues

n/a

## Npm releases

n/a
