### PR TITLE
Fix app ID and app title when creating a new project

### DIFF
--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -143,6 +143,7 @@ const _configureAppConfigs = async (c: RnvContext) => {
                         }
                     } else if (!appConfig.hidden) {
                         appConfig.common = appConfig.common || {};
+                        //TODO: this needs to use bootstrap_metadata to work properly
                         // appConfig.common.title = c.files.project.config?.defaults?.title;
                         // appConfig.common.id = c.files.project.config?.defaults?.id;
 

--- a/packages/engine-core/src/__tests__/tasks.test.ts
+++ b/packages/engine-core/src/__tests__/tasks.test.ts
@@ -152,6 +152,10 @@ test('Execute task.rnv.new', async () => {
     expect(writeFileSync).toHaveBeenCalledTimes(1);
     expect(writeFileSync).toHaveBeenCalledWith(undefined, {
         currentTemplate: '@rnv/template-starter',
+        common:  {
+            id: "com.test.app",
+            title: "testtitle",
+        },
         defaults: {
             supportedPlatforms: ['android', 'ios', 'web'],
         },

--- a/packages/engine-core/src/tasks/task.rnv.new.ts
+++ b/packages/engine-core/src/tasks/task.rnv.new.ts
@@ -347,7 +347,7 @@ export const taskRnvNew = async (c: RnvContext) => {
                 return data.appID;
             },
             validate: (appId) =>
-                !!appId.match(/[a-z]+\.[a-z0-9]+\.[a-z0-9]+/) || 'Please enter a valid appID (com.test.app)',
+                !!appId.match(/^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$/) || 'Please enter a valid appID (com.test.app)',
             message: "What's your App ID?",
         });
 
@@ -665,6 +665,10 @@ export const taskRnvNew = async (c: RnvContext) => {
         ...renativeTemplateConfigExt,
         projectName: data.projectName || 'my-project',
         projectVersion: data.inputVersion || '0.1.0',
+        common: {
+            id: data.inputAppID || 'com.mycompany.myapp',
+            title: data.inputAppTitle || 'My App',
+        },
         workspaceID: data.optionWorkspaces.selectedOption || 'project description',
         // paths: {
         //     appConfigsDir: './appConfigs',

--- a/packages/engine-core/src/tasks/task.rnv.new.ts
+++ b/packages/engine-core/src/tasks/task.rnv.new.ts
@@ -347,7 +347,8 @@ export const taskRnvNew = async (c: RnvContext) => {
                 return data.appID;
             },
             validate: (appId) =>
-                !!appId.match(/^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$/) || 'Please enter a valid appID (com.test.app)',
+                !!appId.match(/^[a-z][a-z0-9_]*(\.[a-z0-9_]+)+[0-9a-z_]$/) ||
+                'Please enter a valid appID (com.test.app)',
             message: "What's your App ID?",
         });
 
@@ -665,6 +666,7 @@ export const taskRnvNew = async (c: RnvContext) => {
         ...renativeTemplateConfigExt,
         projectName: data.projectName || 'my-project',
         projectVersion: data.inputVersion || '0.1.0',
+        //TODO: TEMPORARY WORKAROUND this neds to use bootstrap_metadata to work properly
         common: {
             id: data.inputAppID || 'com.mycompany.myapp',
             title: data.inputAppTitle || 'My App',
@@ -677,9 +679,6 @@ export const taskRnvNew = async (c: RnvContext) => {
         //     platformBuildsDir: './platformBuilds',
         // },
         defaults: {
-            // TODO: these need to move into NEW metadata
-            // title: data.appTitle,
-            // id: data.appID,
             supportedPlatforms: data.optionPlatforms.selectedOptions,
         },
         engines: {},

--- a/packages/template-starter/appConfigs/app/renative.json
+++ b/packages/template-starter/appConfigs/app/renative.json
@@ -3,8 +3,6 @@
     "extendsTemplate": "@rnv/template-starter/appConfigs/base/renative.json",
     "id": "app",
     "common": {
-        "id": "com.rnv.myapp",
-        "title": "Hello ReNative",
         "description": "ReNative App",
         "buildSchemes": {},
         "runtime": {


### PR DESCRIPTION
## Description

- properly set title and appid to common when creating a new project
- remove title and appid from appConfigs/app, otherwise they'll overwrite renative.json ones

## Related issues

- https://github.com/flexn-io/renative/issues/1244

## Npm releases

n/a
