### PR TITLE
removed the catching of errors_ executeRnv

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,8 +19,6 @@ const terminateProcesses = (): void => {
         console.log(e);
     }
     runningProcesses.length = 0;
-
-    process.exit(0);
 };
 
 export const run = () => {
@@ -57,12 +55,15 @@ export const run = () => {
 
     process.on('SIGINT', () => {
         terminateProcesses();
+        process.exit(0);
     });
 
     executeRnv({ cmd: cmdValue, subCmd: cmdOption, program, process, spinner: Spinner, prompt: Prompt, logger: Logger })
-        .then(() => logComplete(!getContext().runtime.keepSessionActive))
+        .then(() => {
+            logComplete(!getContext().runtime.keepSessionActive);
+        })
         .catch((e: unknown) => {
-            logError(e);
             terminateProcesses();
+            logError(e, true);
         });
 };

--- a/packages/rnv/src/runner.ts
+++ b/packages/rnv/src/runner.ts
@@ -10,6 +10,7 @@ import {
     executeRnvCore,
     getConfigProp,
     loadWorkspacesConfigSync,
+    logError,
     logInitialize,
     registerEngine,
 } from '@rnv/core';
@@ -33,26 +34,21 @@ export const executeRnv = async ({
     prompt: RnvApiPrompt;
     logger: RnvApiLogger;
 }) => {
-    try {
-        // set mono and ci if json is enabled
-        if (program.json) {
-            program.mono = true;
-            program.ci = true;
-        }
-
-        createRnvApi({ spinner, prompt, analytics: Analytics, logger, getConfigProp, doResolve });
-        createRnvContext({ program, process, cmd, subCmd, RNV_HOME_DIR });
-
-        logInitialize();
-        loadWorkspacesConfigSync();
-
-        Analytics.initialize();
-
-        await registerEngine(EngineCore);
-
-        await executeRnvCore();
-    } catch (e) {
-        console.log(e);
-        // logError(e);
+    // set mono and ci if json is enabled
+    if (program.json) {
+        program.mono = true;
+        program.ci = true;
     }
+
+    createRnvApi({ spinner, prompt, analytics: Analytics, logger, getConfigProp, doResolve });
+    createRnvContext({ program, process, cmd, subCmd, RNV_HOME_DIR });
+
+    logInitialize();
+    loadWorkspacesConfigSync();
+
+    Analytics.initialize();
+
+    await registerEngine(EngineCore);
+
+    await executeRnvCore();
 };


### PR DESCRIPTION
## Description

- executeRnv catches errors itself and does not pass them on.

## Related issues

- https://github.com/flexn-io/renative/issues/1286

## Npm releases

n/a
