### PR TITLE
fix/creating_project_with_spaces_in_name

### DIFF
--- a/packages/engine-core/src/tasks/task.rnv.new.ts
+++ b/packages/engine-core/src/tasks/task.rnv.new.ts
@@ -303,8 +303,8 @@ export const taskRnvNew = async (c: RnvContext) => {
         inputProjectName = inputProjectNameObj?.inputProjectName;
     }
 
-    data.projectName = inputProjectName;
-    c.paths.project.dir = path.join(c.paths.CURRENT_DIR, data.projectName.replace(/(\s+)/g, '_'));
+    data.projectName = inputProjectName.replace(/(\s+)/g, '_');
+    c.paths.project.dir = path.join(c.paths.CURRENT_DIR, data.projectName);
 
     if (fsExistsSync(c.paths.project.dir)) {
         const { confirm } = await inquirerPrompt({


### PR DESCRIPTION
## Description

- Spaces in the project name are changed to underscores and project cannot be runned

## Related issues

- https://github.com/flexn-io/renative/issues/905

## Npm releases

n/a
