### PR TITLE
Fix "Cannot find module 'metro-config' on new project"

### DIFF
--- a/packages/engine-rn-macos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-macos/src/adapters/metroAdapter.ts
@@ -1,5 +1,5 @@
 import { Env } from '@rnv/core';
-import { InputConfigT } from 'metro-config';
+import { InputConfig } from '@rnv/sdk-react-native';
 
 const path = require('path');
 
@@ -28,7 +28,7 @@ function blacklist(additionalBlacklist: RegExp[]) {
     return new RegExp(`(${(additionalBlacklist || []).concat(sharedBlacklist).map(escapeRegExp).join('|')})$`);
 }
 
-export const withRNVMetro = (config: InputConfigT): InputConfigT => {
+export const withRNVMetro = (config: InputConfig): InputConfig => {
     const projectPath = process.env.RNV_PROJECT_ROOT || process.cwd();
 
     const watchFolders = [path.resolve(projectPath, 'node_modules')];

--- a/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
@@ -52,7 +52,7 @@ export const withRNVMetro = (config: InputConfig) => {
 
     const exts: string = env.RNV_EXTENSIONS || '';
 
-    const cnfRnv = {
+    const cnfRnv: InputConfig = {
         cacheStores: [
             new FileStore({
                 root: path.join(os.tmpdir(), 'metro-cache-tvos'),

--- a/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
@@ -1,6 +1,5 @@
 import { Env } from '@rnv/core';
-import { withMetroConfig, mergeConfig } from '@rnv/sdk-react-native'
-import { InputConfigT } from 'metro-config';
+import { withMetroConfig, mergeConfig, InputConfig } from '@rnv/sdk-react-native';
 
 const path = require('path');
 const os = require('os');
@@ -31,7 +30,7 @@ function blacklist(additionalBlacklist: RegExp[]) {
     return new RegExp(`(${(additionalBlacklist || []).concat(sharedBlacklist).map(escapeRegExp).join('|')})$`);
 }
 
-export const withRNVMetro = (config: InputConfigT) => {
+export const withRNVMetro = (config: InputConfig) => {
     const projectPath = env.RNV_PROJECT_ROOT || process.cwd();
 
     const defaultConfig = withMetroConfig(projectPath);

--- a/packages/engine-rn-windows/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-windows/src/adapters/metroAdapter.ts
@@ -1,7 +1,7 @@
 const path = require('path');
 import { Env } from '@rnv/core';
 import fs from 'fs';
-import { InputConfigT } from 'metro-config';
+import { InputConfig } from '@rnv/sdk-react-native';
 
 const sharedBlacklist = [
     /node_modules\/react\/dist\/.*/,
@@ -28,7 +28,7 @@ function blacklist(additionalBlacklist: RegExp[]) {
     return new RegExp(`(${(additionalBlacklist || []).concat(sharedBlacklist).map(escapeRegExp).join('|')})$`);
 }
 
-export const withRNVMetro = (config: InputConfigT): InputConfigT => {
+export const withRNVMetro = (config: InputConfig): InputConfig => {
     const projectPath = process.env.RNV_PROJECT_ROOT || process.cwd();
     const rnwPath = fs.realpathSync(path.resolve(require.resolve('react-native-windows/package.json'), '..'));
 

--- a/packages/engine-rn/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn/src/adapters/metroAdapter.ts
@@ -1,6 +1,5 @@
 import { Env } from '@rnv/core';
-import { withMetroConfig, mergeConfig } from '@rnv/sdk-react-native'
-import { InputConfigT } from 'metro-config';
+import { withMetroConfig, mergeConfig, InputConfig } from '@rnv/sdk-react-native';
 
 // TODO merge with packages/engine-rn-macos/src/adapters/metroAdapter.ts and place in @rnv/sdk-react-native
 const path = require('path');
@@ -30,7 +29,7 @@ function blacklist(additionalBlacklist: RegExp[]) {
     return new RegExp(`(${(additionalBlacklist || []).concat(sharedBlacklist).map(escapeRegExp).join('|')})$`);
 }
 
-export const withRNVMetro = (config: InputConfigT): InputConfigT => {
+export const withRNVMetro = (config: InputConfig): InputConfig => {
     const projectPath = env.RNV_PROJECT_ROOT || process.cwd();
 
     const defaultConfig = withMetroConfig(projectPath);

--- a/packages/sdk-react-native/src/adapters.ts
+++ b/packages/sdk-react-native/src/adapters.ts
@@ -1,6 +1,9 @@
 import merge from 'deepmerge';
-import type { ConfigT } from 'metro-config';
+import type { ConfigT, InputConfigT } from 'metro-config';
+
 import { getDefaultConfig, mergeConfig } from 'metro-config';
+
+export type InputConfig = InputConfigT;
 
 const getApplicationId = () => {
     const appId = process.env.RNV_APP_ID;

--- a/packages/sdk-react-native/src/adapters.ts
+++ b/packages/sdk-react-native/src/adapters.ts
@@ -1,8 +1,6 @@
 import merge from 'deepmerge';
 import type { ConfigT, InputConfigT } from 'metro-config';
 
-import { getDefaultConfig, mergeConfig } from 'metro-config';
-
 export type InputConfig = InputConfigT;
 
 const getApplicationId = () => {
@@ -139,12 +137,12 @@ export const withMetroConfig = (projectRoot: string): ConfigT => {
         },
         watchFolders: [],
     };
+    const { mergeConfig, getDefaultConfig } = require('metro-config');
 
-    return mergeConfig(
-        // @ts-expect-error: `getDefaultConfig` is not typed correctly
-        getDefaultConfig.getDefaultValues(projectRoot),
-        config
-    );
+    return mergeConfig(getDefaultConfig.getDefaultValues(projectRoot), config);
 };
 
-export { mergeConfig };
+export const mergeConfig = (config1: ConfigT, config2: InputConfig) => {
+    const mc = require('metro-config');
+    return mc.mergeConfig(config1, config2);
+};


### PR DESCRIPTION
## Description

- move direct imports of metro-config behind rn sdk

## Related issues

- https://github.com/flexn-io/renative/issues/1287

## Npm releases

n/a
