### PR TITLE
Fix/windows

### DIFF
--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -29,10 +29,11 @@ const populateLinkingInfo = (ctx: RnvContext) => {
     //TODO: find better way to deal with linking?
     ctx.paths.IS_LINKED = path.dirname(ctx.paths.rnv.dir).split(path.sep).pop() === 'packages';
 
-    const npxLoc = '/node_modules/.bin/rnv';
+    const npxLoc = isSystemWin ? '\\rnv\\bin\\index.js' : '/node_modules/.bin/rnv';
     const rnvPath = process.argv[1];
     const rnvExecWorkspaceRoot = rnvPath.split(npxLoc)[0];
-    const isNpxMode = ctx.paths.project.dir.includes(rnvExecWorkspaceRoot);
+
+    const isNpxMode = path.join(ctx.paths.project.dir, 'node_modules').includes(rnvExecWorkspaceRoot);
 
     ctx.paths.IS_NPX_MODE = isNpxMode;
 };

--- a/packages/core/src/crypto/index.ts
+++ b/packages/core/src/crypto/index.ts
@@ -18,7 +18,9 @@ export const getEnvVar = (c: RnvContext) => {
         logError('package.json requires `name` field. cannot generate ENV variables for crypto');
         return;
     }
-    const p1 = c.paths.workspace.dir.split('/').pop()?.replace?.('.', '');
+    const splitDelimiter = isSystemWin ? '\\' : '/';
+
+    const p1 = c.paths.workspace.dir.split(splitDelimiter).pop()?.replace?.('.', '');
     const p2 = c.files.project.package.name.replace('@', '').replace('/', '_').replace(/-/g, '_');
     const envVar = `CRYPTO_${p1}_${p2}`.toUpperCase();
     logDebug('encrypt looking for env var:', envVar);


### PR DESCRIPTION
## Description

- fix ENV variable name generation for crypto
- npx isn't detected on Windows <= different path to the file being executed

## Related issues

- https://github.com/flexn-io/renative/issues/1294
- https://github.com/flexn-io/renative/issues/1293

## Npm releases

n/a
