### PR TITLE
Fix Android eject bundle 

### DIFF
--- a/packages/sdk-react-native/src/androidRunner.ts
+++ b/packages/sdk-react-native/src/androidRunner.ts
@@ -69,7 +69,12 @@ export const packageReactNativeAndroid = async (c: RnvContext) => {
         }
 
         await executeAsync(c, cmd, {
-            env: { ...CoreEnvVars.BASE(), ...EnvVars.RNV_REACT_NATIVE_PATH(), ...EnvVars.RNV_APP_ID() },
+            env: {
+                ...CoreEnvVars.RNV_EXTENSIONS(),
+                ...CoreEnvVars.BASE(),
+                ...EnvVars.RNV_REACT_NATIVE_PATH(),
+                ...EnvVars.RNV_APP_ID(),
+            },
         });
 
         logInfo('ANDROID PACKAGE FINISHED');


### PR DESCRIPTION
## Description

- Android bundle command was missing the RNV_EXTENSIONS env variable and throwing a nice error.

## Related issues

- https://github.com/flexn-io/renative/issues/1307

## Npm releases

n/a
