### PR TITLE
Remove deprecated hermes config

### DIFF
--- a/buildHooks/src/prePublish.js
+++ b/buildHooks/src/prePublish.js
@@ -41,44 +41,47 @@ const setPackageVersions = (c, version, versionedPackages) => {
     });
 };
 
-const updateDeps = (pkgConfig, depKey, packageNamesAll, packageConfigs, semVer = '') => {
-    const { pkgFile, rnvFile } = pkgConfig;
+const updatePkgDeps = (pkgConfig, depKey, packageName, packageConfigs, semVer = '') => {
+    const { pkgFile } = pkgConfig;
 
-    packageNamesAll.forEach((v) => {
-        if (pkgFile) {
-            let hasChanges = false;
-            const currVer = pkgFile?.[depKey]?.[v];
-            if (currVer) {
-                const newVer = `${semVer}${packageConfigs[v].pkgFile?.version}`;
+    if (pkgFile) {
+        let hasChanges = false;
+        const currVer = pkgFile?.[depKey]?.[packageName];
+        if (currVer) {
+            const newVer = `${semVer}${packageConfigs[packageName].pkgFile?.version}`;
 
-                if (currVer !== newVer) {
-                    console.log('Found linked dependency to update:', v, currVer, newVer);
-                    hasChanges = true;
-                    pkgFile[depKey][v] = newVer;
-                }
-            }
-            if (hasChanges) {
-                const output = fixPackageObject(pkgFile);
-                writeFileSync(pkgConfig.pkgPath, output, 4, true);
+            if (currVer !== newVer) {
+                console.log('Found linked dependency to update:', packageName, currVer, newVer);
+                hasChanges = true;
+                pkgFile[depKey][packageName] = newVer;
             }
         }
-        if (rnvFile) {
-            let hasRnvChanges = false;
-            const templateVer = rnvFile?.templates?.[v]?.version;
-            if (templateVer) {
-                const newVer = `${semVer}${packageConfigs[v].pkgFile?.version}`;
-                if (templateVer !== newVer) {
-                    console.log('Found linked plugin dependency to update:', v, templateVer, newVer);
-                    hasRnvChanges = true;
-                    rnvFile.templates[v].version = newVer;
-                }
-            }
-            if (hasRnvChanges) {
-                const output = fixPackageObject(rnvFile);
-                writeFileSync(pkgConfig.rnvPath, output, 4, true);
+        if (hasChanges) {
+            const output = fixPackageObject(pkgFile);
+            writeFileSync(pkgConfig.pkgPath, output, 4, true);
+        }
+    }
+};
+
+const updateRenativeDeps = (pkgConfig, packageName, packageConfigs) => {
+    const { rnvFile } = pkgConfig;
+
+    if (rnvFile) {
+        let hasRnvChanges = false;
+        const templateVer = rnvFile?.templates?.[packageName]?.version;
+        if (templateVer) {
+            const newVer = `${packageConfigs[packageName].pkgFile?.version}`;
+            if (templateVer !== newVer) {
+                console.log('Found linked plugin dependency to update:', packageName, templateVer, newVer);
+                hasRnvChanges = true;
+                rnvFile.templates[packageName].version = newVer;
             }
         }
-    });
+        if (hasRnvChanges) {
+            const output = fixPackageObject(rnvFile);
+            writeFileSync(pkgConfig.rnvPath, output, 4, true);
+        }
+    }
 };
 
 export const prePublish = async (c) => {
@@ -150,10 +153,13 @@ export const prePublish = async (c) => {
 
     packageNamesAll.forEach((pkgName) => {
         const pkgConfig = packageConfigs[pkgName];
-        updateDeps(pkgConfig, 'dependencies', packageNamesAll, packageConfigs);
-        updateDeps(pkgConfig, 'devDependencies', packageNamesAll, packageConfigs);
-        updateDeps(pkgConfig, 'optionalDependencies', packageNamesAll, packageConfigs);
-        updateDeps(pkgConfig, 'peerDependencies', packageNamesAll, packageConfigs, '^');
+        packageNamesAll.forEach((v) => {
+            updatePkgDeps(pkgConfig, 'dependencies', v, packageConfigs);
+            updatePkgDeps(pkgConfig, 'devDependencies', v, packageConfigs);
+            updatePkgDeps(pkgConfig, 'optionalDependencies', v, packageConfigs);
+            updatePkgDeps(pkgConfig, 'peerDependencies', v, packageConfigs, '^');
+            updateRenativeDeps(pkgConfig, v, packageConfigs);
+        });
     });
 
     copyFileSync(path.join(c.paths.project.dir, 'README.md'), path.join(pkgDirPath, 'renative/README.md'));

--- a/packages/app-harness/appConfigs/base/renative.json
+++ b/packages/app-harness/appConfigs/base/renative.json
@@ -143,6 +143,11 @@
                     "signingConfig": "Debug",
                     "bundleAssets": false
                 },
+                "debug-jsc": {
+                    "signingConfig": "Debug",
+                    "bundleAssets": false,
+                    "reactNativeEngine": "jsc"
+                },
                 "test": {
                     "signingConfig": "Debug",
                     "bundleAssets": true
@@ -288,6 +293,11 @@
                 "debug": {
                     "bundleAssets": false,
                     "environment": "development"
+                },
+                "debug-engine-rn-web": {
+                    "bundleAssets": false,
+                    "environment": "development",
+                    "engine": "engine-rn-web"
                 },
                 "test": {
                     "bundleAssets": false,

--- a/packages/app-harness/src/app/index.tsx
+++ b/packages/app-harness/src/app/index.tsx
@@ -5,6 +5,7 @@ const App = () => {
     return (
         <View>
             <Text>ReNative Harness</Text>
+            <Text>{`hermes: ${typeof HermesInternal === 'object' && HermesInternal !== null ? 'yes' : 'no'}`}</Text>
         </View>
     );
 };

--- a/packages/core/jsonSchema/rnv.app.json
+++ b/packages/core/jsonSchema/rnv.app.json
@@ -1197,6 +1197,15 @@
                 "firebaseId": {
                   "type": "string"
                 },
+                "reactNativeEngine": {
+                  "type": "string",
+                  "enum": [
+                    "jsc",
+                    "hermes"
+                  ],
+                  "default": "hermes",
+                  "description": "Allows you to define specific native render engine to be used"
+                },
                 "exportOptions": {
                   "type": "object",
                   "properties": {
@@ -1671,6 +1680,9 @@
                       },
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/firebaseId"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/reactNativeEngine"
                       },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/exportOptions"
@@ -2623,6 +2635,9 @@
                 "firebaseId": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/firebaseId"
                 },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/reactNativeEngine"
+                },
                 "exportOptions": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/exportOptions"
                 },
@@ -2827,6 +2842,9 @@
                       },
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/firebaseId"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/reactNativeEngine"
                       },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/exportOptions"

--- a/packages/core/jsonSchema/rnv.app.json
+++ b/packages/core/jsonSchema/rnv.app.json
@@ -389,19 +389,6 @@
                   "default": "Debug",
                   "description": "Equivalent to running `./gradlew/assembleDebug` or `./gradlew/assembleRelease`"
                 },
-                "reactNativeEngine": {
-                  "type": "string",
-                  "enum": [
-                    "jsc",
-                    "v8-android",
-                    "v8-android-nointl",
-                    "v8-android-jit",
-                    "v8-android-jit-nointl",
-                    "hermes"
-                  ],
-                  "default": "hermes",
-                  "description": "Allows you to define specific native render engine to be used"
-                },
                 "minSdkVersion": {
                   "type": "number",
                   "default": 28,
@@ -489,6 +476,19 @@
                 "newArchEnabled": {
                   "type": "boolean",
                   "description": "Enables new arch for android. Default: false"
+                },
+                "reactNativeEngine": {
+                  "type": "string",
+                  "enum": [
+                    "jsc",
+                    "v8-android",
+                    "v8-android-nointl",
+                    "v8-android-jit",
+                    "v8-android-jit-nointl",
+                    "hermes"
+                  ],
+                  "default": "hermes",
+                  "description": "Allows you to define specific native render engine to be used"
                 },
                 "templateAndroid": {
                   "type": "object",
@@ -897,9 +897,6 @@
                       "signingConfig": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/signingConfig"
                       },
-                      "reactNativeEngine": {
-                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
-                      },
                       "minSdkVersion": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/minSdkVersion"
                       },
@@ -959,6 +956,9 @@
                       },
                       "newArchEnabled": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/newArchEnabled"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateAndroid": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid"
@@ -1197,15 +1197,6 @@
                 "firebaseId": {
                   "type": "string"
                 },
-                "reactNativeEngine": {
-                  "type": "string",
-                  "enum": [
-                    "jsc",
-                    "hermes"
-                  ],
-                  "default": "hermes",
-                  "description": "Allows you to define specific native render engine to be used"
-                },
                 "exportOptions": {
                   "type": "object",
                   "properties": {
@@ -1238,6 +1229,9 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
                 },
                 "templateXcode": {
                   "type": "object",
@@ -1681,11 +1675,11 @@
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/firebaseId"
                       },
-                      "reactNativeEngine": {
-                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/reactNativeEngine"
-                      },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/exportOptions"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateXcode": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode"
@@ -2635,11 +2629,11 @@
                 "firebaseId": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/firebaseId"
                 },
-                "reactNativeEngine": {
-                  "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/reactNativeEngine"
-                },
                 "exportOptions": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/exportOptions"
+                },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
                 },
                 "templateXcode": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode"
@@ -2843,11 +2837,11 @@
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/firebaseId"
                       },
-                      "reactNativeEngine": {
-                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/reactNativeEngine"
-                      },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/exportOptions"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateXcode": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode"
@@ -2967,6 +2961,9 @@
                 },
                 "BrowserWindow": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/macos/properties/BrowserWindow"
+                },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
                 },
                 "templateVSProject": {
                   "type": "object",
@@ -3188,6 +3185,9 @@
                       },
                       "BrowserWindow": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/macos/properties/BrowserWindow"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateVSProject": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/windows/properties/templateVSProject"

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -748,19 +748,6 @@
                   "default": "Debug",
                   "description": "Equivalent to running `./gradlew/assembleDebug` or `./gradlew/assembleRelease`"
                 },
-                "reactNativeEngine": {
-                  "type": "string",
-                  "enum": [
-                    "jsc",
-                    "v8-android",
-                    "v8-android-nointl",
-                    "v8-android-jit",
-                    "v8-android-jit-nointl",
-                    "hermes"
-                  ],
-                  "default": "hermes",
-                  "description": "Allows you to define specific native render engine to be used"
-                },
                 "minSdkVersion": {
                   "type": "number",
                   "default": 28,
@@ -848,6 +835,19 @@
                 "newArchEnabled": {
                   "type": "boolean",
                   "description": "Enables new arch for android. Default: false"
+                },
+                "reactNativeEngine": {
+                  "type": "string",
+                  "enum": [
+                    "jsc",
+                    "v8-android",
+                    "v8-android-nointl",
+                    "v8-android-jit",
+                    "v8-android-jit-nointl",
+                    "hermes"
+                  ],
+                  "default": "hermes",
+                  "description": "Allows you to define specific native render engine to be used"
                 },
                 "templateAndroid": {
                   "type": "object",
@@ -1256,9 +1256,6 @@
                       "signingConfig": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/signingConfig"
                       },
-                      "reactNativeEngine": {
-                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
-                      },
                       "minSdkVersion": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/minSdkVersion"
                       },
@@ -1318,6 +1315,9 @@
                       },
                       "newArchEnabled": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/newArchEnabled"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateAndroid": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid"
@@ -1556,15 +1556,6 @@
                 "firebaseId": {
                   "type": "string"
                 },
-                "reactNativeEngine": {
-                  "type": "string",
-                  "enum": [
-                    "jsc",
-                    "hermes"
-                  ],
-                  "default": "hermes",
-                  "description": "Allows you to define specific native render engine to be used"
-                },
                 "exportOptions": {
                   "type": "object",
                   "properties": {
@@ -1597,6 +1588,9 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
                 },
                 "templateXcode": {
                   "type": "object",
@@ -2040,11 +2034,11 @@
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/firebaseId"
                       },
-                      "reactNativeEngine": {
-                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/reactNativeEngine"
-                      },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/exportOptions"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateXcode": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode"
@@ -2994,11 +2988,11 @@
                 "firebaseId": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/firebaseId"
                 },
-                "reactNativeEngine": {
-                  "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/reactNativeEngine"
-                },
                 "exportOptions": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/exportOptions"
+                },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
                 },
                 "templateXcode": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode"
@@ -3202,11 +3196,11 @@
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/firebaseId"
                       },
-                      "reactNativeEngine": {
-                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/reactNativeEngine"
-                      },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/exportOptions"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateXcode": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode"
@@ -3326,6 +3320,9 @@
                 },
                 "BrowserWindow": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/macos/properties/BrowserWindow"
+                },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
                 },
                 "templateVSProject": {
                   "type": "object",
@@ -3547,6 +3544,9 @@
                       },
                       "BrowserWindow": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/macos/properties/BrowserWindow"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/reactNativeEngine"
                       },
                       "templateVSProject": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/windows/properties/templateVSProject"

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -1556,6 +1556,15 @@
                 "firebaseId": {
                   "type": "string"
                 },
+                "reactNativeEngine": {
+                  "type": "string",
+                  "enum": [
+                    "jsc",
+                    "hermes"
+                  ],
+                  "default": "hermes",
+                  "description": "Allows you to define specific native render engine to be used"
+                },
                 "exportOptions": {
                   "type": "object",
                   "properties": {
@@ -2030,6 +2039,9 @@
                       },
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/firebaseId"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/reactNativeEngine"
                       },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/exportOptions"
@@ -2982,6 +2994,9 @@
                 "firebaseId": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/firebaseId"
                 },
+                "reactNativeEngine": {
+                  "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/reactNativeEngine"
+                },
                 "exportOptions": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/exportOptions"
                 },
@@ -3186,6 +3201,9 @@
                       },
                       "firebaseId": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/firebaseId"
+                      },
+                      "reactNativeEngine": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/reactNativeEngine"
                       },
                       "exportOptions": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/exportOptions"

--- a/packages/core/src/schema/platforms/android.ts
+++ b/packages/core/src/schema/platforms/android.ts
@@ -3,10 +3,12 @@ import { CommonSchemaFragment } from '../common';
 import { PlatformBaseFragment } from './fragments/base';
 import { PlatformAndroidFragment } from './fragments/android';
 import { TemplateAndroidFragment } from './fragments/templateAndroid';
+import { PlatformReactNativeFragment } from './fragments/reactNative';
 
 export const PlatformAndroidSchema = z.object({
     ...CommonSchemaFragment,
     ...PlatformBaseFragment,
     ...PlatformAndroidFragment,
+    ...PlatformReactNativeFragment,
     ...TemplateAndroidFragment,
 });

--- a/packages/core/src/schema/platforms/fragments/android.ts
+++ b/packages/core/src/schema/platforms/fragments/android.ts
@@ -13,12 +13,6 @@ export const PlatformAndroidFragment = {
             .default('Debug')
             .describe('Equivalent to running `./gradlew/assembleDebug` or `./gradlew/assembleRelease`')
     ),
-    reactNativeEngine: z.optional(
-        z
-            .enum(['jsc', 'v8-android', 'v8-android-nointl', 'v8-android-jit', 'v8-android-jit-nointl', 'hermes'])
-            .default('hermes')
-            .describe('Allows you to define specific native render engine to be used')
-    ),
     minSdkVersion: z.optional(
         z.number().default(28).describe('Minimum Android SDK version device has to have in order for app to run')
     ),

--- a/packages/core/src/schema/platforms/fragments/reactNative.ts
+++ b/packages/core/src/schema/platforms/fragments/reactNative.ts
@@ -1,1 +1,10 @@
-export const PlatformReactNativeFragment = {};
+import { z } from 'zod';
+
+export const PlatformReactNativeFragment = {
+    reactNativeEngine: z.optional(
+        z
+            .enum(['jsc', 'v8-android', 'v8-android-nointl', 'v8-android-jit', 'v8-android-jit-nointl', 'hermes'])
+            .default('hermes')
+            .describe('Allows you to define specific native render engine to be used')
+    ),
+};

--- a/packages/core/src/schema/platforms/ios.ts
+++ b/packages/core/src/schema/platforms/ios.ts
@@ -3,10 +3,12 @@ import { PlatformBaseFragment } from './fragments/base';
 import { PlatformiOSFragment } from './fragments/ios';
 import { CommonSchemaFragment } from '../common';
 import { TemplateXcodeFragment } from './fragments/templateXcode';
+import { PlatformReactNativeFragment } from './fragments/reactNative';
 
 export const PlatformiOSSchema = z.object({
     ...CommonSchemaFragment,
     ...PlatformBaseFragment,
     ...PlatformiOSFragment,
+    ...PlatformReactNativeFragment,
     ...TemplateXcodeFragment,
 });

--- a/packages/core/src/schema/platforms/macos.ts
+++ b/packages/core/src/schema/platforms/macos.ts
@@ -4,11 +4,13 @@ import { CommonSchemaFragment } from '../common';
 import { PlatformiOSFragment } from './fragments/ios';
 import { PlatformElectronFragment } from './fragments/electron';
 import { TemplateXcodeFragment } from './fragments/templateXcode';
+import { PlatformReactNativeFragment } from './fragments/reactNative';
 
 export const PlatformMacosSchema = z.object({
     ...CommonSchemaFragment,
     ...PlatformBaseFragment,
     ...PlatformiOSFragment,
+    ...PlatformReactNativeFragment,
     ...TemplateXcodeFragment,
     ...PlatformElectronFragment,
 });

--- a/packages/core/src/schema/platforms/windows.ts
+++ b/packages/core/src/schema/platforms/windows.ts
@@ -3,10 +3,12 @@ import { PlatformBaseFragment } from './fragments/base';
 import { CommonSchemaFragment } from '../common';
 import { PlatformElectronFragment } from './fragments/electron';
 import { PlatformWindowsFragment } from './fragments/windows';
+import { PlatformReactNativeFragment } from './fragments/reactNative';
 
 export const PlatformWindowsSchema = z.object({
     ...CommonSchemaFragment,
     ...PlatformBaseFragment,
     ...PlatformElectronFragment,
+    ...PlatformReactNativeFragment,
     ...PlatformWindowsFragment,
 });

--- a/packages/sdk-android/src/gradleParser.ts
+++ b/packages/sdk-android/src/gradleParser.ts
@@ -148,8 +148,6 @@ maven { url("${doResolve('jsc-android', true, { forceForwardPaths: true })}/dist
 `;
 
     c.payload.pluginConfigAndroid.appBuildGradleImplementations += "    implementation 'org.webkit:android-jsc:+'\n";
-
-    c.payload.pluginConfigAndroid.injectHermes = '    enableHermes: false,';
 };
 
 const setReactNativeEngineHermes = (c: Context) => {
@@ -158,11 +156,6 @@ const setReactNativeEngineHermes = (c: Context) => {
   maven { url "${doResolve('react-native', true, { forceForwardPaths: true })}/android" }
   maven { url("${doResolve('jsc-android', true, { forceForwardPaths: true })}/dist") }
   `;
-
-    c.payload.pluginConfigAndroid.injectHermes = `    enableHermes: true,
-hermesCommand: "{{PATH_HERMES_ENGINE}}/%OS-BIN%/hermes",
-deleteDebugFilesForVariant: { false },
-    `;
 };
 
 const setReactNativeEngineV8 = (c: Context) => {
@@ -183,8 +176,6 @@ const setReactNativeEngineV8 = (c: Context) => {
                 getUseDeveloperSupport()
             )
         }`;
-
-    c.payload.pluginConfigAndroid.injectHermes = '    enableHermes: false,';
 
     c.payload.pluginConfigAndroid.packagingOptions += `
     exclude '**/libjsc.so'`;
@@ -468,10 +459,6 @@ ${chalk().white(c.paths.workspace?.appConfig?.configsPrivate?.join('\n'))}`);
         {
             pattern: '{{PLUGIN_LOCAL_PROPERTIES}}',
             override: c.payload.pluginConfigAndroid.localProperties,
-        },
-        {
-            pattern: '{{INJECT_HERMES}}',
-            override: c.payload.pluginConfigAndroid.injectHermes,
         },
         {
             pattern: '{{PATH_REACT_NATIVE}}',

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -425,7 +425,6 @@ export const configureProject = async (c: Context) => {
         appBuildGradleImplementations: '',
         resourceStrings: [],
         appBuildGradleAfterEvaluate: '',
-        injectHermes: '',
         kotlinVersion: '',
         googleServicesVersion: '',
         buildToolsVersion: '',

--- a/packages/sdk-android/src/types.ts
+++ b/packages/sdk-android/src/types.ts
@@ -5,7 +5,6 @@ export type Payload = {
         gradleWrapperVersion: string;
         injectReactNativeEngine: string;
         appBuildGradleImplementations: string;
-        injectHermes: string;
         pluginApplicationImports: string;
         reactNativeHostMethods: string;
         packagingOptions: string;

--- a/packages/template-starter/package.json
+++ b/packages/template-starter/package.json
@@ -87,10 +87,6 @@
         "tsc": "tsc --noEmit --composite false",
         "watch": "tsc --watch --preserveWatchOutput --noEmit"
     },
-    "dependencies": {
-        "@lightningjs/sdk": "^5.4.1",
-        "raf": "3.4.1"
-    },
     "devDependencies": {
         "@flexn/assets-renative-outline": "0.3.2",
         "@flexn/graybox": "1.0.0-feat.12",

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -68,7 +68,7 @@
     },
     "templates": {
         "@rnv/template-starter": {
-            "version": "^1.0.0-rc.7"
+            "version": "1.0.0-rc.7"
         }
     },
     "currentTemplate": "@rnv/template-starter",
@@ -109,9 +109,7 @@
             "minSdkVersion": 21,
             "extendPlatform": "android",
             "engine": "engine-rn-tvos",
-            "includedPermissions": [
-                "INTERNET"
-            ]
+            "includedPermissions": ["INTERNET"]
         },
         "web": {
             "engine": "engine-rn-next"

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -109,7 +109,9 @@
             "minSdkVersion": 21,
             "extendPlatform": "android",
             "engine": "engine-rn-tvos",
-            "includedPermissions": ["INTERNET"]
+            "includedPermissions": [
+                "INTERNET"
+            ]
         },
         "web": {
             "engine": "engine-rn-next"


### PR DESCRIPTION
## Description

- removed INJECT_HERMES, not used anymore. Hermes is configured with HERMES_ENABLED now

## Related issues

- https://github.com/flexn-io/renative/issues/885

## Npm releases

n/a
