### PR TITLE
Android packageId build cleanup

### DIFF
--- a/packages/sdk-android/src/javaParser.ts
+++ b/packages/sdk-android/src/javaParser.ts
@@ -1,20 +1,21 @@
-import path from 'path';
 import {
     OverridesOptions,
     PlatformKey,
     RenativeConfigPluginPlatform,
     RnvContext,
+    addSystemInjects,
     getAppFolder,
     getAppId,
     getBuildFilePath,
+    getConfigProp,
     getEntryFile,
     getGetJsBundleFile,
-    getConfigProp,
     getIP,
-    addSystemInjects,
-    logWarning,
+    removeDirSync,
     writeCleanFile,
 } from '@rnv/core';
+import { mkdirSync } from 'fs';
+import path from 'path';
 import { Context } from './types';
 
 const JS_BUNDLE_DEFAULTS: Partial<Record<PlatformKey, string>> = {
@@ -22,10 +23,52 @@ const JS_BUNDLE_DEFAULTS: Partial<Record<PlatformKey, string>> = {
     androidwear: '"assets://index.androidwear.bundle"',
 };
 
+export const parseFlipperSync = (c: Context, scheme: 'debug' | 'release') => {
+    const appFolder = getAppFolder(c);
+    const { platform } = c;
+
+    const appId = getAppId(c, c.platform);
+    // console.log('appId', appId);
+    const javaPackageArray = appId?.split('.') || [];
+
+    const javaPackagePath = `app/src/${scheme}/java/${javaPackageArray.join('/')}`;
+
+    // cleanup potentially existing folders from previous builds with different appId
+    removeDirSync(path.join(appFolder, `app/src/${scheme}/java`));
+
+    mkdirSync(path.join(appFolder, javaPackagePath), { recursive: true });
+
+    const templatePath = `app/src/${scheme}/java/rnv_template/ReactNativeFlipper.java.tpl`;
+    const applicationPath = `${javaPackagePath}/ReactNativeFlipper.java`;
+
+    const injects: OverridesOptions = [{ pattern: '{{APPLICATION_ID}}', override: getAppId(c, platform) }];
+
+    addSystemInjects(c, injects);
+
+    writeCleanFile(
+        getBuildFilePath(c, platform, templatePath),
+        path.join(appFolder, applicationPath),
+        injects,
+        undefined,
+        c
+    );
+};
+
 export const parseMainApplicationSync = (c: Context) => {
     const appFolder = getAppFolder(c);
     const { platform } = c;
-    const applicationPath = 'app/src/main/java/rnv/MainApplication.kt';
+
+    if (!platform) return;
+
+    const appId = getAppId(c, c.platform);
+    // console.log('appId', appId);
+    const javaPackageArray = appId?.split('.') || [];
+
+    const javaPackagePath = `app/src/main/java/${javaPackageArray.join('/')}`;
+    mkdirSync(path.join(appFolder, javaPackagePath), { recursive: true });
+
+    const templatePath = 'app/src/main/java/rnv_template/MainApplication.java.tpl';
+    const applicationPath = `${javaPackagePath}/MainApplication.java`;
     const bundleAssets = getConfigProp(c, platform, 'bundleAssets');
     const bundleDefault = JS_BUNDLE_DEFAULTS[platform];
     const bundleFile: string =
@@ -72,7 +115,7 @@ export const parseMainApplicationSync = (c: Context) => {
     addSystemInjects(c, injects);
 
     writeCleanFile(
-        getBuildFilePath(c, platform, applicationPath),
+        getBuildFilePath(c, platform, templatePath),
         path.join(appFolder, applicationPath),
         injects,
         undefined,
@@ -83,10 +126,20 @@ export const parseMainApplicationSync = (c: Context) => {
 export const parseMainActivitySync = (c: RnvContext) => {
     const appFolder = getAppFolder(c);
     const { platform } = c;
-    const activityPath = 'app/src/main/java/rnv/MainActivity.kt';
+
+    const appId = getAppId(c, c.platform);
+    // console.log('appId', appId);
+    const javaPackageArray = appId?.split('.') || [];
+
+    const javaPackagePath = `app/src/main/java/${javaPackageArray.join('/')}`;
+    mkdirSync(path.join(appFolder, javaPackagePath), { recursive: true });
+
+    const templatePath = 'app/src/main/java/rnv_template/MainActivity.java.tpl';
+    const activityPath = `${javaPackagePath}/MainActivity.java`;
 
     const templateAndroid = getConfigProp(c, platform, 'templateAndroid', {});
-    const mainActivity = templateAndroid?.MainActivity_java; // TODO ADD KOTLIN WHEN READY
+
+    const mainActivity = templateAndroid?.MainActivity_java;
 
     c.payload.pluginConfigAndroid.injectActivityOnCreate =
         mainActivity?.onCreate || 'super.onCreate(savedInstanceState)';
@@ -118,7 +171,7 @@ export const parseMainActivitySync = (c: RnvContext) => {
     addSystemInjects(c, injects);
 
     writeCleanFile(
-        getBuildFilePath(c, platform, activityPath),
+        getBuildFilePath(c, platform, templatePath),
         path.join(appFolder, activityPath),
         injects,
         undefined,
@@ -129,7 +182,11 @@ export const parseMainActivitySync = (c: RnvContext) => {
 export const parseSplashActivitySync = (c: Context) => {
     const appFolder = getAppFolder(c);
     const { platform } = c;
-    const splashPath = 'app/src/main/java/rnv/SplashActivity.kt';
+    const appId = getAppId(c, c.platform);
+    const javaPackageArray = appId?.split('.') || [];
+
+    const splashTemplatePath = 'app/src/main/java/rnv_template/SplashActivity.java.tpl';
+    const splashPath = `app/src/main/java/${javaPackageArray.join('/')}/SplashActivity.java`;
 
     // TODO This is temporary ANDROIDX support. whole kotlin parser will be refactored in the near future
     const enableAndroidX = getConfigProp(c, platform, 'enableAndroidX', true);
@@ -151,12 +208,25 @@ export const parseSplashActivitySync = (c: Context) => {
 
     addSystemInjects(c, injects);
 
-    writeCleanFile(getBuildFilePath(c, platform, splashPath), path.join(appFolder, splashPath), injects, undefined, c);
+    writeCleanFile(
+        getBuildFilePath(c, platform, splashTemplatePath),
+        path.join(appFolder, splashPath),
+        injects,
+        undefined,
+        c
+    );
 };
 
-export const injectPluginKotlinSync = (c: any, plugin: any, key: any, pkg: any) => {
-    if (plugin.activityImports instanceof Array) {
-        plugin.activityImports.forEach((activityImport: any) => {
+export const injectPluginKotlinSync = (
+    c: RnvContext,
+    plugin: RenativeConfigPluginPlatform,
+    key: string,
+    pkg: string | undefined
+) => {
+    const templ = plugin.templateAndroid;
+    const mainActivity = templ?.MainActivity_java;
+    if (mainActivity?.imports) {
+        mainActivity.imports.forEach((activityImport) => {
             // Avoid duplicate imports
             if (c.payload.pluginConfigAndroid.pluginActivityImports.indexOf(activityImport) === -1) {
                 c.payload.pluginConfigAndroid.pluginActivityImports += `import ${activityImport}\n`;
@@ -164,77 +234,49 @@ export const injectPluginKotlinSync = (c: any, plugin: any, key: any, pkg: any) 
         });
     }
 
-    if (plugin.activityMethods instanceof Array) {
+    if (mainActivity?.methods) {
         c.payload.pluginConfigAndroid.pluginActivityMethods += '\n';
-        c.payload.pluginConfigAndroid.pluginActivityMethods += `${plugin.activityMethods.join('\n    ')}`;
+        c.payload.pluginConfigAndroid.pluginActivityMethods += `${mainActivity.methods.join('\n    ')}`;
     }
 
-    const { mainActivity } = plugin;
     if (mainActivity) {
-        if (mainActivity.createMethods instanceof Array) {
+        if (mainActivity.createMethods) {
             c.payload.pluginConfigAndroid.pluginActivityCreateMethods += '\n';
             c.payload.pluginConfigAndroid.pluginActivityCreateMethods += `${mainActivity.createMethods.join('\n    ')}`;
         }
 
-        if (mainActivity.resultMethods instanceof Array) {
+        if (mainActivity.resultMethods) {
             c.payload.pluginConfigAndroid.pluginActivityResultMethods += '\n';
             c.payload.pluginConfigAndroid.pluginActivityResultMethods += `${mainActivity.resultMethods.join('\n    ')}`;
         }
-
-        if (mainActivity.imports instanceof Array) {
-            mainActivity.imports.forEach((v: any) => {
-                c.payload.pluginConfigAndroid.pluginActivityImports += `import ${v}\n`;
-            });
-        }
-
-        if (mainActivity.methods instanceof Array) {
-            c.payload.pluginConfigAndroid.pluginActivityMethods += '\n';
-            c.payload.pluginConfigAndroid.pluginActivityMethods += `${mainActivity.methods.join('\n    ')}`;
-        }
-    }
-
-    if (plugin.imports) {
-        plugin.imports.forEach((v: any) => {
-            c.payload.pluginConfigAndroid.pluginApplicationImports += `import ${v}\n`;
-        });
     }
 
     _injectPackage(c, plugin, pkg);
 
-    if (plugin.MainApplication) {
-        if (plugin.MainApplication.packages) {
-            plugin.MainApplication.packages.forEach((v: any) => {
-                _injectPackage(c, plugin, v);
-            });
-        }
+    const mainApplication = templ?.MainApplication_java;
+
+    if (mainApplication?.packages) {
+        mainApplication.packages.forEach((v) => {
+            _injectPackage(c, plugin, v);
+        });
     }
 
-    const { mainApplication } = plugin;
-    if (mainApplication) {
-        if (mainApplication.createMethods instanceof Array) {
-            c.payload.pluginConfigAndroid.pluginApplicationCreateMethods += '\n';
-            c.payload.pluginConfigAndroid.pluginApplicationCreateMethods += `${mainApplication.createMethods.join(
-                '\n    '
-            )}`;
-        }
-
-        if (mainApplication.imports instanceof Array) {
-            mainApplication.imports.forEach((v: any) => {
-                c.payload.pluginConfigAndroid.pluginApplicationImports += `import ${v}\n`;
-            });
-        }
-
-        if (mainApplication.methods instanceof Array) {
-            c.payload.pluginConfigAndroid.pluginApplicationMethods += '\n';
-            c.payload.pluginConfigAndroid.pluginApplicationMethods += `${mainApplication.methods.join('\n    ')}`;
-        }
+    if (mainApplication?.createMethods) {
+        c.payload.pluginConfigAndroid.pluginApplicationCreateMethods += '\n';
+        c.payload.pluginConfigAndroid.pluginApplicationCreateMethods += `${mainApplication.createMethods.join(
+            '\n    '
+        )}`;
     }
 
-    if (plugin.mainApplicationMethods) {
-        logWarning(
-            `Plugin ${key} in ${c.paths.project.config} is using DEPRECATED "${c.platform}": { MainApplicationMethods }. Use "${c.platform}": { "mainApplication": { "methods": []}} instead`
-        );
-        c.payload.pluginConfigAndroid.pluginApplicationMethods += `\n${plugin.mainApplicationMethods}\n`;
+    if (mainApplication?.imports) {
+        mainApplication.imports.forEach((v) => {
+            c.payload.pluginConfigAndroid.pluginApplicationImports += `import ${v}\n`;
+        });
+    }
+
+    if (mainApplication?.methods) {
+        c.payload.pluginConfigAndroid.pluginApplicationMethods += '\n';
+        c.payload.pluginConfigAndroid.pluginApplicationMethods += `${mainApplication.methods.join('\n    ')}`;
     }
 };
 
@@ -243,7 +285,7 @@ const _injectPackage = (c: RnvContext, plugin: RenativeConfigPluginPlatform, pkg
         c.payload.pluginConfigAndroid.pluginApplicationImports += `import ${pkg}\n`;
     }
     let packageParams = '';
-    const mainApplication = plugin.templateAndroid?.MainApplication_java; // TODO ADD KOTLIN WHEN READY
+    const mainApplication = plugin.templateAndroid?.MainApplication_java;
     if (mainApplication?.packageParams) {
         packageParams = mainApplication.packageParams.join(',');
     }

--- a/packages/sdk-android/src/kotlinParser.ts
+++ b/packages/sdk-android/src/kotlinParser.ts
@@ -27,7 +27,7 @@ export const parseMainApplicationSync = (c: Context) => {
     const { platform } = c;
     const applicationPath = 'app/src/main/java/rnv/MainApplication.kt';
     const bundleAssets = getConfigProp(c, platform, 'bundleAssets');
-    const bundleDefault = JS_BUNDLE_DEFAULTS[platform];
+    const bundleDefault = JS_BUNDLE_DEFAULTS[platform!];
     const bundleFile: string =
         getGetJsBundleFile(c, platform) || bundleAssets
             ? `"assets://${getEntryFile(c, platform)}.bundle"`

--- a/packages/sdk-android/src/kotlinParser.ts
+++ b/packages/sdk-android/src/kotlinParser.ts
@@ -11,6 +11,7 @@ import {
     getEntryFile,
     getGetJsBundleFile,
     getIP,
+    removeDirSync,
     writeCleanFile,
 } from '@rnv/core';
 import { mkdirSync } from 'fs';
@@ -31,6 +32,10 @@ export const parseFlipperSync = (c: Context, scheme: 'debug' | 'release') => {
     const javaPackageArray = appId?.split('.') || [];
 
     const javaPackagePath = `app/src/${scheme}/java/${javaPackageArray.join('/')}`;
+
+    // cleanup potentially existing folders from previous builds with different appId
+    removeDirSync(path.join(appFolder, `app/src/${scheme}/java`));
+
     mkdirSync(path.join(appFolder, javaPackagePath), { recursive: true });
 
     const templatePath = `app/src/${scheme}/java/rnv_template/ReactNativeFlipper.java.tpl`;

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -34,7 +34,7 @@ import {
     DEFAULTS,
     RnvPlatform,
     logInfo,
-    removeDirSync,
+    cleanFolder,
 } from '@rnv/core';
 import { parseAndroidManifestSync, injectPluginManifestSync } from './manifestParser';
 import {
@@ -398,7 +398,7 @@ export const configureProject = async (c: Context) => {
     fsWriteFileSync(path.join(appFolder, `app/src/main/assets/${outputFile}.bundle`), '{}');
 
     // cleanup potentially existing folders from previous builds with different appId
-    removeDirSync(path.join(appFolder, 'app/src/main/java'));
+    await cleanFolder(path.join(appFolder, 'app/src/main/java'));
 
     // INJECTORS
     c.payload.pluginConfigAndroid = {

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -43,7 +43,7 @@ import {
     parseMainApplicationSync,
     injectPluginKotlinSync,
     parseFlipperSync,
-} from './kotlinParser';
+} from './javaParser';
 import {
     parseAppBuildGradleSync,
     parseBuildGradleSync,

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -34,6 +34,7 @@ import {
     DEFAULTS,
     RnvPlatform,
     logInfo,
+    removeDirSync,
 } from '@rnv/core';
 import { parseAndroidManifestSync, injectPluginManifestSync } from './manifestParser';
 import {
@@ -395,6 +396,9 @@ export const configureProject = async (c: Context) => {
     // await createJavaPackageFolders(c, appFolder);
     mkdirSync(path.join(appFolder, 'app/src/main/assets'));
     fsWriteFileSync(path.join(appFolder, `app/src/main/assets/${outputFile}.bundle`), '{}');
+
+    // cleanup potentially existing folders from previous builds with different appId
+    removeDirSync(path.join(appFolder, 'app/src/main/java'));
 
     // INJECTORS
     c.payload.pluginConfigAndroid = {


### PR DESCRIPTION
## Description

- Empty java folder when starting a new build to prevent older builds with different packageId leftovers to interfere with current one

## Related issues

- https://github.com/flexn-io/renative/issues/1329

## Npm releases

n/a
