### PR TITLE
Fix issue with node 18.0.0 and ip package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
         "detect-port": "1.3.0",
         "esbuild": "^0.12.1",
         "execa": "5.1.1",
-        "ip": "1.1.5",
+        "ip": "1.1.8",
         "kill-port": "1.6.1",
         "lodash.get": "4.4.2",
         "lodash.intersection": "4.4.0",

--- a/packages/sdk-webpack/package.json
+++ b/packages/sdk-webpack/package.json
@@ -49,7 +49,7 @@
         "fs-extra": "^10.0.0",
         "html-webpack-plugin": "^5.5.0",
         "identity-obj-proxy": "^3.0.0",
-        "ip": "1.1.5",
+        "ip": "1.1.8",
         "mini-css-extract-plugin": "^2.4.5",
         "postcss": "^8.4.4",
         "postcss-flexbugs-fixes": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11767,14 +11767,9 @@ ip-regex@^4.0.0, ip-regex@^4.1.0:
   resolved "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
-ip@1.1.5:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha512-rBtCAQAJm8A110nbwn6YdveUnuZH3WrC36IwkRXxDnq53JvXA2NVQvB7IHyKomxK1MJ4VDNw3UtFDdXQ+AvLYA==
-
-ip@^1.1.5, ip@^1.1.8:
+ip@1.1.8, ip@^1.1.5, ip@^1.1.8:
   version "1.1.8"
-  resolved "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
   integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
 
 ip@^2.0.0:


### PR DESCRIPTION
## Description

- Apparently node 18.0.0 can cause issues for "ip" package. https://github.com/indutny/node-ip/pull/114. @Marius456  encountered this issue. As a bonus latest version fixes this as well https://github.com/indutny/node-ip/issues/109
<img width="620" alt="Screenshot 2024-01-03 at 17 44 52" src="https://github.com/flexn-io/renative/assets/4787898/1f766222-996e-4dad-9d7b-ee1bb0543f8c">

## Related issues

- none

## Npm releases

n/a
