### PR TITLE
Inject ios permissions on eject

### DIFF
--- a/packages/app-harness/appConfigs/harness/renative.json
+++ b/packages/app-harness/appConfigs/harness/renative.json
@@ -1,7 +1,7 @@
 {
     "$schema": "../../../../.rnv/schema/rnv.app.json",
     "extend": "base",
-    "id": "template",
+    "id": "harness",
     "skipBootstrapCopy": true,
     "common": {
         "id": "renative.harness",

--- a/packages/app-harness/package.json
+++ b/packages/app-harness/package.json
@@ -45,7 +45,8 @@
         "react-native": "0.72.4",
         "react-native-gesture-handler": "2.13.1",
         "react-native-tvos": "0.72.4-0",
-        "react-native-web": "0.19.9"
+        "react-native-web": "0.19.9",
+        "react-native-permissions": "3.10.1"
     },
     "devDependencies": {
         "@flexn/assets-renative-outline": "0.3.3",

--- a/packages/app-harness/renative.json
+++ b/packages/app-harness/renative.json
@@ -4,5 +4,18 @@
     "projectName": "@rnv/app-harness",
     "crypto": {
         "path": "./secrets/privateConfigs.enc"
+    },
+    "plugins": {
+        "react-native-permissions": "3.10.1"
+    },
+    "permissions": {
+        "ios": {
+            "NSCalendarsUsageDescription": {
+                "desc": "Calendars usage description"
+            },
+            "NSContactsUsageDescription": {
+                "desc": "Contacts usage description"
+            }
+        }
     }
 }

--- a/packages/plugins/pluginTemplates/renative.plugins.json
+++ b/packages/plugins/pluginTemplates/renative.plugins.json
@@ -3203,76 +3203,7 @@
             "version": "1.0.2"
         },
         "react-native-permissions": {
-            "android": {
-                "package": "com.zoontek.rnpermissions.RNPermissionsPackage"
-            },
-            "androidtv": {
-                "package": "com.zoontek.rnpermissions.RNPermissionsPackage"
-            },
-            "ios": {
-                "isStatic": true,
-                "podName": "RNPermissions",
-                "staticPods": [
-                    "::startsWith::Permission-"
-                ]
-            },
-            "macos": {
-                "isStatic": true,
-                "podName": "RNPermissions",
-                "staticPods": [
-                    "::startsWith::Permission-"
-                ]
-            },
-            "tvos": {
-                "isStatic": true,
-                "podName": "RNPermissions",
-                "staticPods": [
-                    "::startsWith::Permission-"
-                ]
-            },
-            "version": "3.6.1"
-        },
-        "react-native-permissions-pods": {
-            "ios": {
-                "podNames": [
-                    "Permission-BluetoothPeripheral', :path => '{{PLUGIN_ROOT}}/ios/BluetoothPeripheral",
-                    "Permission-Calendars', :path => '{{PLUGIN_ROOT}}/ios/Calendars",
-                    "Permission-Camera', :path => '{{PLUGIN_ROOT}}/ios/Camera",
-                    "Permission-Contacts', :path => '{{PLUGIN_ROOT}}/ios/Contacts",
-                    "Permission-FaceID', :path => '{{PLUGIN_ROOT}}/ios/FaceID",
-                    "Permission-LocationAlways', :path => '{{PLUGIN_ROOT}}/ios/LocationAlways",
-                    "Permission-LocationWhenInUse', :path => '{{PLUGIN_ROOT}}/ios/LocationWhenInUse",
-                    "Permission-MediaLibrary', :path => '{{PLUGIN_ROOT}}/ios/MediaLibrary",
-                    "Permission-Microphone', :path => '{{PLUGIN_ROOT}}/ios/Microphone",
-                    "Permission-Motion', :path => '{{PLUGIN_ROOT}}/ios/Motion",
-                    "Permission-Notifications', :path => '{{PLUGIN_ROOT}}/ios/Notifications",
-                    "Permission-PhotoLibrary', :path => '{{PLUGIN_ROOT}}/ios/PhotoLibrary",
-                    "Permission-Reminders', :path => '{{PLUGIN_ROOT}}/ios/Reminders",
-                    "Permission-SpeechRecognition', :path => '{{PLUGIN_ROOT}}/ios/SpeechRecognition",
-                    "Permission-StoreKit', :path => '{{PLUGIN_ROOT}}/ios/StoreKit"
-                ]
-            },
-            "macos": {
-                "podNames": [
-                    "Permission-BluetoothPeripheral', :path => '{{PLUGIN_ROOT}}/ios/BluetoothPeripheral",
-                    "Permission-Calendars', :path => '{{PLUGIN_ROOT}}/ios/Calendars",
-                    "Permission-Camera', :path => '{{PLUGIN_ROOT}}/ios/Camera",
-                    "Permission-Contacts', :path => '{{PLUGIN_ROOT}}/ios/Contacts",
-                    "Permission-FaceID', :path => '{{PLUGIN_ROOT}}/ios/FaceID",
-                    "Permission-LocationAlways', :path => '{{PLUGIN_ROOT}}/ios/LocationAlways",
-                    "Permission-LocationWhenInUse', :path => '{{PLUGIN_ROOT}}/ios/LocationWhenInUse",
-                    "Permission-MediaLibrary', :path => '{{PLUGIN_ROOT}}/ios/MediaLibrary",
-                    "Permission-Microphone', :path => '{{PLUGIN_ROOT}}/ios/Microphone",
-                    "Permission-Motion', :path => '{{PLUGIN_ROOT}}/ios/Motion",
-                    "Permission-Notifications', :path => '{{PLUGIN_ROOT}}/ios/Notifications",
-                    "Permission-PhotoLibrary', :path => '{{PLUGIN_ROOT}}/ios/PhotoLibrary",
-                    "Permission-Reminders', :path => '{{PLUGIN_ROOT}}/ios/Reminders",
-                    "Permission-SpeechRecognition', :path => '{{PLUGIN_ROOT}}/ios/SpeechRecognition",
-                    "Permission-StoreKit', :path => '{{PLUGIN_ROOT}}/ios/StoreKit"
-                ]
-            },
-            "no-npm": true,
-            "packageName": "react-native-permissions"
+            "version": "3.10.1"
         },
         "react-native-photo-editor": {
             "android": {

--- a/packages/sdk-apple/src/ejector.ts
+++ b/packages/sdk-apple/src/ejector.ts
@@ -14,6 +14,7 @@ import {
 } from '@rnv/core';
 import { getAppFolderName } from './common';
 import { Context } from './types';
+import { EnvVars } from '@rnv/sdk-react-native';
 
 export const ejectXcodeProject = async (c: Context) => {
     const isMonorepo = getConfigProp(c, c.platform, 'isMonorepo');
@@ -68,9 +69,16 @@ export const ejectXcodeProject = async (c: Context) => {
         const pathNmMatch = `${path.join(rootMonoProjectPath, 'node_modules')}/`;
         const pathNmReplace = './rn_modules/';
 
-        const podfileSanitised = podfileAsString
+        const permissionsMatch = "ENV['REACT_NATIVE_PERMISSIONS_REQUIRED']";
+        const permissionsReplace = EnvVars.REACT_NATIVE_PERMISSIONS_REQUIRED().REACT_NATIVE_PERMISSIONS_REQUIRED;
+
+        let podfileSanitised = podfileAsString
             .replaceAll(pathRnMatch, pathRnReplace)
             .replaceAll(pathNmMatch, pathNmReplace);
+
+        if (podfileSanitised.includes(permissionsMatch) && permissionsReplace) {
+            podfileSanitised = podfileSanitised.replaceAll(permissionsMatch, `'${permissionsReplace.join(',')}'`);
+        }
 
         fsWriteFileSync(podfilePath, podfileSanitised);
     }

--- a/packages/sdk-react-native/src/index.ts
+++ b/packages/sdk-react-native/src/index.ts
@@ -3,3 +3,4 @@ export * from './androidRunner';
 export * from './iosRunner';
 export * from './metroRunner';
 export * from './adapters';
+export * from './env';

--- a/yarn.lock
+++ b/yarn.lock
@@ -17465,6 +17465,11 @@ react-native-gesture-handler@2.13.1:
     lodash "^4.17.21"
     prop-types "^15.7.2"
 
+react-native-permissions@3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.10.1.tgz#cb0171c8d12113869deaabbdfb979aad1a44752b"
+  integrity sha512-Gc5BxxpjZn4QNUDiVeHOO0vXh3AH7ToolmwTJozqC6DsxV7NAf3ttap+8BSmzDR8WxuAM3Cror+YNiBhHJx7/w==
+
 react-native-tvos@0.72.4-0:
   version "0.72.4-0"
   resolved "https://registry.npmjs.org/react-native-tvos/-/react-native-tvos-0.72.4-0.tgz#beb36bac097e272c0e62c5cfe51cd674c7c2aa57"


### PR DESCRIPTION
## Description

- Take permissions into account when ejecting, insert them in podfile
- Cleanup react-native-permissions plugin
- Set harness up for eject testcase 

## Related issues

- https://github.com/flexn-io/renative/issues/1341

## Npm releases

n/a
