### PR TITLE
fix. Improve webpack callback chaining in withRNVNext to execute cust…

### DIFF
--- a/packages/engine-rn-next/src/adapters/nextAdapter.ts
+++ b/packages/engine-rn-next/src/adapters/nextAdapter.ts
@@ -76,7 +76,7 @@ export const withRNVNext = (config: NextConfig) => {
                     .filter((ext) => isServer || !ext.includes('server.'));
             }
             if (typeof config.webpack === 'function') {
-                return config.webpack(config, props);
+                return config.webpack(cfg, props);
             }
             return cfg;
         },

--- a/packages/engine-rn-next/src/adapters/nextAdapter.ts
+++ b/packages/engine-rn-next/src/adapters/nextAdapter.ts
@@ -75,6 +75,9 @@ export const withRNVNext = (config: NextConfig) => {
                     .map((e) => `.${e}`)
                     .filter((ext) => isServer || !ext.includes('server.'));
             }
+            if (typeof config.webpack === 'function') {
+                return config.webpack(config, props);
+            }
             return cfg;
         },
     };


### PR DESCRIPTION
…om webpack callback from downstream.

## Description

- This PR introduces chaining for webpack callback if custom webpack config callback was defined in downstream by user (e.g., next.config.js). (Thx for the debugging guidance from Jacko.)
- Verified with apps generated by @rnv/template-starter.
- `yarn sanity` passed.

## Related issues

- #1359 

## Npm releases

n/a
