### PR TITLE
fix/add_upper_limit_for_cocoapods

### DIFF
--- a/packages/app-harness/Gemfile
+++ b/packages/app-harness/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '~> 1.12'
+gem 'cocoapods', '~> 1.12', '< 1.15'
 gem 'activesupport', '~> 7.0', '<= 7.0.8'
 

--- a/packages/template-starter/Gemfile
+++ b/packages/template-starter/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '~> 1.12'
+gem 'cocoapods', '~> 1.12', '< 1.15'
 gem 'activesupport', '~> 7.0', '<= 7.0.8'
 


### PR DESCRIPTION
## Description

-  ios/tvos fails to build on a new project <=  CocoaPods 1.15.0 : File exists @ syserr_fail2_in

## Related issues

- https://github.com/flexn-io/renative/issues/1368

## Npm releases

n/a
