### PR TITLE
android -> -t do not ask to select device/simulator when needed

### DIFF
--- a/packages/sdk-android/src/__tests__/getAndroidDeviceToRunOn.test.ts
+++ b/packages/sdk-android/src/__tests__/getAndroidDeviceToRunOn.test.ts
@@ -1,0 +1,55 @@
+import { getAndroidDeviceToRunOn } from '../runner';
+import { createRnvApi, createRnvContext, getContext } from '@rnv/core';
+
+jest.mock('../deviceManager', () => {
+    return {
+        mockLaunchAndroidSimulator: jest.fn(),
+        resetAdb: jest.fn(),
+        connectToWifiDevice: jest.fn(),
+        getAndroidTargets: jest.fn(),
+        checkForActiveEmulator: jest.fn(),
+        composeDevicesArray: jest.fn(),
+        askForNewEmulator: jest.fn(),
+    };
+});
+
+beforeAll(() => {
+    createRnvContext();
+    createRnvApi();
+});
+
+describe('getAndroidDeviceToRunOn', () => {
+    it('should return found sim if target is provided and found - npx rnv -p android -t <target>', async () => {
+        //GIVEN
+        const ctx = getContext();
+        ctx.platform = 'android';
+        ctx.program.target = 'existingTarget';
+        ctx.runtime.target = 'defaultTarget';
+        const mockFoundDevice = { name: 'existingTarget', isActive: true, udid: '' };
+        const { getAndroidTargets } = require('../deviceManager');
+        getAndroidTargets.mockResolvedValueOnce([mockFoundDevice]);
+        //WHEN
+
+        const result = await getAndroidDeviceToRunOn(ctx);
+        //THEN
+        expect(result).toEqual(mockFoundDevice);
+    });
+    it('should ask from devices and sims if target is not provided - npx rnv -p android', async () => {
+        //GIVEN
+        const ctx = getContext();
+        ctx.platform = 'android';
+        ctx.program.target = false;
+        ctx.runtime.target = 'defaultTarget';
+        const mockDevicesAndEmulators = [
+            { name: 'simulator1', udid: 'udid1', isActive: true },
+            { name: 'simulator2', udid: 'udid2', isActive: false },
+            // Add more mock targets as needed
+        ];
+        const { getAndroidTargets } = require('../deviceManager');
+        getAndroidTargets.mockResolvedValueOnce(mockDevicesAndEmulators);
+        //WHEN
+
+        // const result = await getAndroidDeviceToRunOn(ctx);
+        //THEN
+    });
+});

--- a/packages/sdk-android/src/__tests__/getAndroidDeviceToRunOn.test.ts
+++ b/packages/sdk-android/src/__tests__/getAndroidDeviceToRunOn.test.ts
@@ -34,22 +34,22 @@ describe('getAndroidDeviceToRunOn', () => {
         //THEN
         expect(result).toEqual(mockFoundDevice);
     });
-    it('should ask from devices and sims if target is not provided - npx rnv -p android', async () => {
-        //GIVEN
-        const ctx = getContext();
-        ctx.platform = 'android';
-        ctx.program.target = false;
-        ctx.runtime.target = 'defaultTarget';
-        const mockDevicesAndEmulators = [
-            { name: 'simulator1', udid: 'udid1', isActive: true },
-            { name: 'simulator2', udid: 'udid2', isActive: false },
-            // Add more mock targets as needed
-        ];
-        const { getAndroidTargets } = require('../deviceManager');
-        getAndroidTargets.mockResolvedValueOnce(mockDevicesAndEmulators);
-        //WHEN
+    // it('should ask from devices and sims if target is not provided - npx rnv -p android', async () => {
+    //     //GIVEN
+    //     const ctx = getContext();
+    //     ctx.platform = 'android';
+    //     ctx.program.target = false;
+    //     ctx.runtime.target = 'defaultTarget';
+    //     const mockDevicesAndEmulators = [
+    //         { name: 'simulator1', udid: 'udid1', isActive: true },
+    //         { name: 'simulator2', udid: 'udid2', isActive: false },
+    //         // Add more mock targets as needed
+    //     ];
+    //     const { getAndroidTargets } = require('../deviceManager');
+    //     getAndroidTargets.mockResolvedValueOnce(mockDevicesAndEmulators);
+    //     //WHEN
 
-        // const result = await getAndroidDeviceToRunOn(ctx);
-        //THEN
-    });
+    //     // const result = await getAndroidDeviceToRunOn(ctx);
+    //     //THEN
+    // });
 });

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -106,7 +106,7 @@ export const getAndroidDeviceToRunOn = async (c: Context) => {
                 logInfo(
                     `The target is specified, but no such emulator or device is available: ${chalk().magenta(
                         _isString(target) ? target : device
-                    )}`
+                    )}. Will try to find available one`
                 );
             }
             const activeDeviceInfoArr = composeDevicesArray(activeDevices);

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -102,10 +102,11 @@ export const getAndroidDeviceToRunOn = async (c: Context) => {
                 return logError('No active devices found, please connect one or remove the device argument', true);
             }
             if (!foundDevice && (isString(target) || isString(device))) {
-                logInfo(
+                return logError(
                     `The target is specified, but no such emulator or device is available: ${chalk().magenta(
                         isString(target) ? target : device
-                    )}. Will try to find available one`
+                    )}`,
+                    true
                 );
             }
             const activeDeviceInfoArr = composeDevicesArray(activeDevices);

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -114,11 +114,10 @@ export const getAndroidDeviceToRunOn = async (c: Context) => {
             const choices = [...activeDeviceInfoArr, ...inactiveDeviceInfoArr];
 
             let chosenEmulator: string;
-
             if (activeDeviceInfoArr.length === 1 && !target) {
                 chosenEmulator = activeDeviceInfoArr[0].value;
                 logInfo(`Found only one active emulator: ${chalk().magenta(chosenEmulator)}. Will use it.`);
-            } else if (activeDeviceInfoArr.length === 0 && inactiveDeviceInfoArr.length === 1) {
+            } else if (activeDeviceInfoArr.length === 0 && inactiveDeviceInfoArr.length === 1 && !target) {
                 //If we have no active devices and only one AVD available let's just launch it.
                 chosenEmulator = inactiveDeviceInfoArr[0].value;
                 logInfo(`Found only one emulator to launch: ${chalk().magenta(chosenEmulator)}. Will use it.`);

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -83,7 +83,7 @@ export const getAndroidDeviceToRunOn = async (c: Context) => {
 
     await resetAdb(c);
 
-    if (target && isString(target) && net.isIP(target.split(':')[0])) {
+    if (target && _isString(target) && net.isIP(target.split(':')[0])) {
         await connectToWifiDevice(c, target);
     }
 
@@ -101,10 +101,10 @@ export const getAndroidDeviceToRunOn = async (c: Context) => {
             if (c.program.device && !activeDevices.length) {
                 return logError('No active devices found, please connect one or remove the device argument', true);
             }
-            if (!foundDevice && (isString(target) || isString(device))) {
+            if (!foundDevice && (_isString(target) || _isString(device))) {
                 return logError(
                     `The target is specified, but no such emulator or device is available: ${chalk().magenta(
-                        isString(target) ? target : device
+                        _isString(target) ? target : device
                     )}`,
                     true
                 );
@@ -525,7 +525,7 @@ export const runAndroidLog = async (c: Context) => {
     return child.then((res) => res.stdout).catch((err) => Promise.reject(`Error: ${err}`));
 };
 
-export const isString = (target: boolean | string): boolean => {
+const _isString = (target: boolean | string): boolean => {
     return typeof target === 'string';
 };
 export { ejectGradleProject };

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -82,9 +82,10 @@ export const getAndroidDeviceToRunOn = async (c: Context) => {
     const { platform } = c;
 
     await resetAdb(c);
+    const targetToConnectWiFi = _isString(target) ? target : device;
 
-    if (target && _isString(target) && net.isIP(target.split(':')[0])) {
-        await connectToWifiDevice(c, target);
+    if (_isString(targetToConnectWiFi) && net.isIP(targetToConnectWiFi.split(':')[0])) {
+        await connectToWifiDevice(c, targetToConnectWiFi);
     }
 
     const devicesAndEmulators = await getAndroidTargets(c, false, false, !!device);
@@ -102,11 +103,10 @@ export const getAndroidDeviceToRunOn = async (c: Context) => {
                 return logError('No active devices found, please connect one or remove the device argument', true);
             }
             if (!foundDevice && (_isString(target) || _isString(device))) {
-                return logError(
+                logInfo(
                     `The target is specified, but no such emulator or device is available: ${chalk().magenta(
                         _isString(target) ? target : device
-                    )}`,
-                    true
+                    )}`
                 );
             }
             const activeDeviceInfoArr = composeDevicesArray(activeDevices);


### PR DESCRIPTION
## Description

- npx rnv run -p android -t do not ask to select target if there is active at least one device or at least one simulator.

## Related issues

- https://github.com/flexn-io/renative/issues/1367

## Npm releases

n/a
