### PR TITLE
remove_question_when_run_decrypt_for_the_first_time

### DIFF
--- a/packages/engine-core/src/tasks/task.rnv.crypto.decrypt.ts
+++ b/packages/engine-core/src/tasks/task.rnv.crypto.decrypt.ts
@@ -73,7 +73,7 @@ export const taskRnvCryptoDecrypt: RnvTaskFn = async (c, parentTask, originTask)
         const wsPath = path.join(c.paths.workspace.dir, projectName);
         const isCryptoReset = c.command === 'crypto' && c.program.reset === true;
 
-        if (c.program.ci !== true && !isCryptoReset) {
+        if (c.program.ci !== true && !isCryptoReset && fsExistsSync(destFolder)) {
             const options = ['Yes - override (recommended)', 'Yes - merge', 'Skip'];
             const { option } = await inquirerPrompt({
                 name: 'option',


### PR DESCRIPTION
## Description

- When there decrypt target folder is deleted rnv shouldn't ask if user wants to override

## Related issues

- https://github.com/flexn-io/renative/issues/1370

## Npm releases

n/a
