### PR TITLE
Remove pod check

### DIFF
--- a/packages/sdk-react-native/src/iosRunner.ts
+++ b/packages/sdk-react-native/src/iosRunner.ts
@@ -11,7 +11,6 @@ import {
     logInfo,
     logDebug,
     fsWriteFileSync,
-    commandExistsSync,
     getContext,
     getCurrentCommand,
     inquirerPrompt,
@@ -199,10 +198,6 @@ export const runCocoaPods = async (c: RnvContext) => {
             ...EnvVars.RCT_NEW_ARCH_ENABLED(),
             ...EnvVars.RNV_SKIP_LINKING(),
         };
-
-        if (!commandExistsSync('pod')) {
-            throw new Error('Cocoapods not installed. Please run `sudo gem install cocoapods`');
-        }
 
         if (c.program.updatePods) {
             await executeAsync(c, 'bundle exec pod update', {


### PR DESCRIPTION
## Description

- Since we're using bundler now there's no need for globally installed cocoapods so this check is useless. Checking if bundler exists is useless as well, it comes preinstalled in Ruby

## Related issues

- GH issues

## Npm releases

n/a
