### PR TITLE
Fix/add extensions to android run

### DIFF
--- a/packages/sdk-react-native/src/androidRunner.ts
+++ b/packages/sdk-react-native/src/androidRunner.ts
@@ -109,6 +109,7 @@ export const runReactNativeAndroid = async (
     return executeAsync(c, command, {
         env: {
             ...CoreEnvVars.BASE(),
+            ...CoreEnvVars.RNV_EXTENSIONS(),
             ...EnvVars.RCT_METRO_PORT(),
             ...EnvVars.RNV_REACT_NATIVE_PATH(),
             ...EnvVars.RNV_APP_ID(),

--- a/packages/sdk-react-native/src/iosRunner.ts
+++ b/packages/sdk-react-native/src/iosRunner.ts
@@ -11,7 +11,6 @@ import {
     logInfo,
     logDebug,
     fsWriteFileSync,
-    commandExistsSync,
     getContext,
     getCurrentCommand,
     inquirerPrompt,
@@ -199,10 +198,6 @@ export const runCocoaPods = async (c: RnvContext) => {
             ...EnvVars.RCT_NEW_ARCH_ENABLED(),
             ...EnvVars.RNV_SKIP_LINKING(),
         };
-
-        if (!commandExistsSync('pod')) {
-            throw new Error('Cocoapods not installed. Please run `sudo gem install cocoapods`');
-        }
 
         if (c.program.updatePods) {
             await executeAsync(c, 'bundle exec pod update', {


### PR DESCRIPTION
## Description

- Added `CoreEnvVars.RNV_EXTENSIONS` to android run, otherwise running in release mode would trigger an error because in that mode Gradle does the JS bundle

merge https://github.com/flexn-io/renative/pull/1400 first

## Related issues

- GH issues

## Npm releases

n/a
