### PR TITLE
Add disclaimer message for webos simulator

### DIFF
--- a/packages/sdk-webos/src/deviceManager.ts
+++ b/packages/sdk-webos/src/deviceManager.ts
@@ -172,6 +172,9 @@ const launchAppOnSimulator = async (c: RnvContext, appPath: string) => {
     }
 
     await execCLI(c, CLI_WEBOS_ARES_LAUNCH, `-s ${version} ${appPath}`);
+    logInfo(
+        `Launched app on webOS TV simulator ${selectedOption}. If you do not see the app opening please close the simulator and try again.`
+    );
 };
 
 // Used for actual devices


### PR DESCRIPTION
## Description

- Webos simulator is stupid and tries to do hot reload on the build folder. This doesn't fly with webpack-dev-server, added message to prompt the users to close the simulator if the app doesn't open and try again

## Related issues

- https://github.com/flexn-io/renative/issues/1396

## Npm releases

n/a
