### PR TITLE
Properly wrap command snippet

### DIFF
--- a/packages/core/jsonSchema/rnv.app.json
+++ b/packages/core/jsonSchema/rnv.app.json
@@ -2313,11 +2313,11 @@
                 },
                 "outputDir": {
                   "type": "string",
-                  "description": "Custom output directory used by nextjs equivalent to \"npx next build\" with custom outputDir. Use relative paths"
+                  "description": "Custom output directory used by nextjs equivalent to `npx next build` with custom outputDir. Use relative paths"
                 },
                 "exportDir": {
                   "type": "string",
-                  "description": "Custom export directory used by nextjs equivalent to \"npx next export --outdir <exportDir>\". Use relative paths"
+                  "description": "Custom export directory used by nextjs equivalent to `npx next export --outdir <exportDir>`. Use relative paths"
                 },
                 "nextTranspileModules": {
                   "type": "array",

--- a/packages/core/jsonSchema/rnv.app.json
+++ b/packages/core/jsonSchema/rnv.app.json
@@ -9,7 +9,7 @@
           "description": "ID of the app in `./appConfigs/[APP_ID]/renative.json`. MUST match APP_ID name of the folder"
         },
         "custom": {
-          "description": "Object ysed to extend your renative with custom props. This allows renative json schema to be validated"
+          "description": "Object used to extend your renative with custom props. This allows renative json schema to be validated"
         },
         "hidden": {
           "type": "boolean",

--- a/packages/core/jsonSchema/rnv.engine.json
+++ b/packages/core/jsonSchema/rnv.engine.json
@@ -5,7 +5,7 @@
       "type": "object",
       "properties": {
         "custom": {
-          "description": "Object ysed to extend your renative with custom props. This allows renative json schema to be validated"
+          "description": "Object used to extend your renative with custom props. This allows renative json schema to be validated"
         },
         "id": {
           "type": "string",

--- a/packages/core/jsonSchema/rnv.plugin.json
+++ b/packages/core/jsonSchema/rnv.plugin.json
@@ -862,7 +862,7 @@
           "$ref": "#/definitions/rnv.plugin/properties/tizen"
         },
         "custom": {
-          "description": "Object ysed to extend your renative with custom props. This allows renative json schema to be validated"
+          "description": "Object used to extend your renative with custom props. This allows renative json schema to be validated"
         },
         "$schema": {
           "type": "string",

--- a/packages/core/jsonSchema/rnv.plugins.json
+++ b/packages/core/jsonSchema/rnv.plugins.json
@@ -5,7 +5,7 @@
       "type": "object",
       "properties": {
         "custom": {
-          "description": "Object ysed to extend your renative with custom props. This allows renative json schema to be validated"
+          "description": "Object used to extend your renative with custom props. This allows renative json schema to be validated"
         },
         "pluginTemplates": {
           "type": "object",

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -303,7 +303,7 @@
           "description": "List of engines available in this project"
         },
         "custom": {
-          "description": "Object ysed to extend your renative with custom props. This allows renative json schema to be validated"
+          "description": "Object used to extend your renative with custom props. This allows renative json schema to be validated"
         },
         "enableHookRebuild": {
           "type": "boolean",

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -2672,11 +2672,11 @@
                 },
                 "outputDir": {
                   "type": "string",
-                  "description": "Custom output directory used by nextjs equivalent to \"npx next build\" with custom outputDir. Use relative paths"
+                  "description": "Custom output directory used by nextjs equivalent to `npx next build` with custom outputDir. Use relative paths"
                 },
                 "exportDir": {
                   "type": "string",
-                  "description": "Custom export directory used by nextjs equivalent to \"npx next export --outdir <exportDir>\". Use relative paths"
+                  "description": "Custom export directory used by nextjs equivalent to `npx next export --outdir <exportDir>`. Use relative paths"
                 },
                 "nextTranspileModules": {
                   "type": "array",

--- a/packages/core/src/schema/platforms/fragments/nextjs.ts
+++ b/packages/core/src/schema/platforms/fragments/nextjs.ts
@@ -5,13 +5,13 @@ export const PlatformNextJsFragment = {
     outputDir: z
         .string()
         .describe(
-            'Custom output directory used by nextjs equivalent to "npx next build" with custom outputDir. Use relative paths'
+            'Custom output directory used by nextjs equivalent to `npx next build` with custom outputDir. Use relative paths'
         )
         .optional(),
     exportDir: z
         .string()
         .describe(
-            'Custom export directory used by nextjs equivalent to "npx next export --outdir <exportDir>". Use relative paths'
+            'Custom export directory used by nextjs equivalent to `npx next export --outdir <exportDir>`. Use relative paths'
         )
         .optional(),
     nextTranspileModules: z.optional(z.array(z.string())),

--- a/packages/core/src/schema/shared/index.ts
+++ b/packages/core/src/schema/shared/index.ts
@@ -16,7 +16,7 @@ export const HexColor = z.string().min(4).max(9).regex(/^#/);
 export const Ext = z
     .any()
     .describe(
-        'Object ysed to extend your renative with custom props. This allows renative json schema to be validated'
+        'Object used to extend your renative with custom props. This allows renative json schema to be validated'
     );
 
 export const ExtendTemplate = z

--- a/packages/engine-core/src/tasks/task.rnv.crypto.decrypt.ts
+++ b/packages/engine-core/src/tasks/task.rnv.crypto.decrypt.ts
@@ -207,7 +207,7 @@ and we will try to help!
 };
 
 const Task: RnvTask = {
-    description: 'Decrypt encrypted project files into local ~/<wokspace>/<project>/..',
+    description: 'Decrypt encrypted project files into local `~/<wokspace>/<project>/..`',
     fn: taskRnvCryptoDecrypt,
     task: TASK_CRYPTO_DECRYPT,
     params: PARAMS.withBase(),

--- a/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
+++ b/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
@@ -232,7 +232,7 @@ export const taskRnvCryptoEncrypt: RnvTaskFn = async (c, _parentTask, originTask
 };
 
 const Task: RnvTask = {
-    description: 'Encrypts secure files from ~/<wokspace>/<project>/.. to project',
+    description: 'Encrypts secure files from `~/<wokspace>/<project>/..` to project',
     fn: taskRnvCryptoEncrypt,
     task: TASK_CRYPTO_ENCRYPT,
     params: PARAMS.withBase(),


### PR DESCRIPTION
## Description

- Docusaurus doesn't like "<tag>" wrapped in quotes, it tries to parse it as JSX. Wrapping the command snippet in `these` fixes it
- Fixed typo

## Related issues

- GH issues

## Npm releases

n/a
