### PR TITLE
Don't ask to update project if version is unknown

### DIFF
--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -612,12 +612,13 @@ export const versionCheck = async (c: RnvContext) => {
         return true;
     }
     c.runtime.rnvVersionRunner = c.files.rnv?.package?.version || 'unknown';
-    c.runtime.rnvVersionProject = c.files.project?.package?.devDependencies?.rnv || 'unknown';
+    c.runtime.rnvVersionProject =
+        c.files.project?.package?.devDependencies?.rnv || c.files.project?.package?.dependencies?.rnv || 'unknown';
     logTask(
         `versionCheck:rnvRunner:${c.runtime.rnvVersionRunner},rnvProject:${c.runtime.rnvVersionProject}`,
         chalk().grey
     );
-    if (c.runtime.rnvVersionRunner && c.runtime.rnvVersionProject && c.runtime.rnvVersionRunner !== 'unknown') {
+    if (c.runtime.rnvVersionRunner && c.runtime.rnvVersionProject) {
         if (c.runtime.rnvVersionRunner !== c.runtime.rnvVersionProject && !c.program.skipRnvCheck) {
             const recCmd = chalk().white(`$ npx ${getCurrentCommand(true)}`);
             const actionNoUpdate = 'Continue and skip updating package.json';

--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -617,7 +617,7 @@ export const versionCheck = async (c: RnvContext) => {
         `versionCheck:rnvRunner:${c.runtime.rnvVersionRunner},rnvProject:${c.runtime.rnvVersionProject}`,
         chalk().grey
     );
-    if (c.runtime.rnvVersionRunner && c.runtime.rnvVersionProject) {
+    if (c.runtime.rnvVersionRunner && c.runtime.rnvVersionProject && c.runtime.rnvVersionRunner !== 'unknown') {
         if (c.runtime.rnvVersionRunner !== c.runtime.rnvVersionProject && !c.program.skipRnvCheck) {
             const recCmd = chalk().white(`$ npx ${getCurrentCommand(true)}`);
             const actionNoUpdate = 'Continue and skip updating package.json';


### PR DESCRIPTION
## Description

- rnv assumes it's a devDep in projects, will trigger a weird update message if it's in dependencies.
```
[ warn ] [project configure] You are running $rnv v1.0.0-rc.11 against project built with rnv vunknown. This might result in unexpected behaviour!
It is recommended that you run your rnv command with npx prefix: $ npx npx rnv hooks run -x generateDocs . or manually update your devDependencies.rnv version in your package.json.
? What to do next? (Use arrow keys)
❯ Continue and skip updating package.json
  Continue and update package.json
  Upgrade project to 1.0.0-rc.11
```

## Related issues

- GH issues

## Npm releases

n/a
