### PR TITLE
Linux: can't run template starter for first time

### DIFF
--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -57,7 +57,8 @@
             "tizenwatch",
             "tizenmobile",
             "kaios",
-            "chromecast"
+            "chromecast",
+            "linux"
         ],
         "defaultCommandSchemes": {
             "run": "debug",
@@ -110,9 +111,7 @@
             "minSdkVersion": 21,
             "extendPlatform": "android",
             "engine": "engine-rn-tvos",
-            "includedPermissions": [
-                "INTERNET"
-            ]
+            "includedPermissions": ["INTERNET"]
         },
         "web": {
             "engine": "engine-rn-next"


### PR DESCRIPTION
## Description

- Fix linux first time build error.

## Related issues

- https://github.com/flexn-io/renative/issues/1289

## Npm releases

n/a
