### PR TITLE
fix/add_warning_for_special_characters_crypto

### DIFF
--- a/packages/engine-core/src/tasks/task.rnv.crypto.decrypt.ts
+++ b/packages/engine-core/src/tasks/task.rnv.crypto.decrypt.ts
@@ -109,6 +109,7 @@ export const taskRnvCryptoDecrypt: RnvTaskFn = async (c, parentTask, originTask)
 
 ${getEnvExportCmd(envVar, 'REPLACE_WITH_ENV_VARIABLE')}
 
+Make sure you take into account special characters that might need to be escaped.
 `);
         }
         if (!fsExistsSync(source)) {
@@ -153,6 +154,7 @@ ${chalk().green('SUGGESTION:')}
 
 ${chalk().yellow('STEP 1:')}
 check if your ENV VAR is correct: ${getEnvExportCmd(envVar, '***********')}
+Make sure you take into account special characters that might need to be escaped
 or if someone did not encrypt ${chalk().white(source)} with a different key
 
 ${chalk().yellow('STEP 2:')}

--- a/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
+++ b/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
@@ -162,7 +162,9 @@ ${getEnvExportCmd(envVar, 'REPLACE_WITH_ENV_VARIABLE')}
                 key
             )}. Make sure you keep it safe! Pass it with --key on decryption or set it as following env variable:
 
-${getEnvExportCmd(envVar, key)}
+${getEnvExportCmd(envVar, key)} 
+
+Make sure you take into account special characters that might need to be escaped
 
 `);
             c.process.env[envVar] = key;

--- a/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
+++ b/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
@@ -139,7 +139,6 @@ RNV will create it for you, make sure you add whatever you want encrypted in it 
     }
 
     let key = c.program.key || c.process.env[envVar];
-    console.log(key, 'key');
     let keyGenerated = false;
     if (!key) {
         const { confirm } = await inquirerPrompt({

--- a/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
+++ b/packages/engine-core/src/tasks/task.rnv.crypto.encrypt.ts
@@ -139,6 +139,7 @@ RNV will create it for you, make sure you add whatever you want encrypted in it 
     }
 
     let key = c.program.key || c.process.env[envVar];
+    console.log(key, 'key');
     let keyGenerated = false;
     if (!key) {
         const { confirm } = await inquirerPrompt({
@@ -154,6 +155,8 @@ RNV will create it for you, make sure you add whatever you want encrypted in it 
             return Promise.reject(`encrypt: You must pass ${chalk().white('--key')} or have env var defined:
 
 ${getEnvExportCmd(envVar, 'REPLACE_WITH_ENV_VARIABLE')}
+
+Make sure you take into account special characters that might need to be escaped
 
 `);
         }

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -111,9 +111,7 @@
             "minSdkVersion": 21,
             "extendPlatform": "android",
             "engine": "engine-rn-tvos",
-            "includedPermissions": [
-                "INTERNET"
-            ]
+            "includedPermissions": ["INTERNET"]
         },
         "web": {
             "engine": "engine-rn-next"


### PR DESCRIPTION
## Description

- Special characters might need to be escaped when setting the env variable or passing the key

## Related issues

- https://github.com/flexn-io/renative/issues/1294

## Npm releases

n/a
