### PR TITLE
Fix/firetv manifest allowbackup

### DIFF
--- a/packages/sdk-android/src/manifestParser.ts
+++ b/packages/sdk-android/src/manifestParser.ts
@@ -240,6 +240,7 @@ export const parseAndroidManifestSync = (c: Context) => {
                 _mergeNodeChildren(baseManifestFile, manifestObj.children);
             }
         });
+        //TODO: Should be mark as deprecated
 
         // appConfigs/base/plugins.json PLUGIN CONFIG OVERRIDES
         parsePlugins(c, platform, (_plugin, pluginPlat) => {

--- a/packages/sdk-android/supportFiles/AndroidManifest_firetv.json
+++ b/packages/sdk-android/supportFiles/AndroidManifest_firetv.json
@@ -19,7 +19,7 @@
             "android:icon": "@mipmap/ic_launcher",
             "android:roundIcon": "@mipmap/ic_launcher",
             "android:banner": "@drawable/banner",
-            "android:allowBackup": false,
+            "android:allowBackup": true,
             "android:theme": "@style/AppTheme",
             "children": [
                 {


### PR DESCRIPTION
## Description

- The manifest merge failed due to a conflict in the allowBackup values.

## Related issues

- https://github.com/flexn-io/renative/issues/1425

## Npm releases

n/a
