### PR TITLE
CLI improvements

### DIFF
--- a/__mocks__/@rnv/core.ts
+++ b/__mocks__/@rnv/core.ts
@@ -21,14 +21,21 @@ const _chalkCols: any = {
     blue: (v) => v,
     cyan: (v) => v,
     magenta: (v) => v,
+    bold: (v) => v,
+    rgb: (v) => v,
 };
-_chalkCols.rgb = () => (v) => v;
-_chalkCols.bold = _chalkCols;
+function mockChalk() {
+    return _chalkCols;
+}
+Object.assign(mockChalk, _chalkCols);
+Object.keys(_chalkCols).forEach((key) => {
+    _chalkCols[key] = mockChalk;
+});
 const _chalkMono = {
     ..._chalkCols,
 };
 
-export const generateRnvConfigPathObj = () => {
+const generateRnvConfigPathObj = () => {
     return {
         configs: [],
         configsPrivate: [],
@@ -45,7 +52,7 @@ export const generateRnvConfigPathObj = () => {
     };
 };
 
-export const generateRnvConfigFileObj = () => {
+const generateRnvConfigFileObj = () => {
     return {
         configs: [],
         configsLocal: [],
@@ -53,7 +60,7 @@ export const generateRnvConfigFileObj = () => {
     };
 };
 
-export const generateContextDefaults = (ctx?: Context) => {
+const generateContextDefaults = (ctx?: Context) => {
     const runtime: any = {
         currentEngine: { rootPath: '' },
         enginesByPlatform: {},
@@ -244,90 +251,10 @@ export const generateContextDefaults = (ctx?: Context) => {
         },
     };
 };
-
-rnvcore.getEngineRunnerByPlatform = () => ({
-    getOriginalPlatformTemplatesDir: () => 'sometemptdir',
-});
-rnvcore.executeTask = jest.fn();
-rnvcore.shouldSkipTask = () => false;
-rnvcore.generatePlatformChoices = () => [];
-rnvcore.executeAsync = jest.fn();
-rnvcore.removeDirs = jest.fn();
-rnvcore.fsExistsSync = jest.fn();
-rnvcore.fsReaddirSync = () => [];
-rnvcore.getRealPath = () => '';
-rnvcore.copyFolderContentsRecursiveSync = jest.fn();
-rnvcore.getConfigProp = jest.fn();
-rnvcore.confirmActiveBundler = () => null;
-rnvcore.getAppFolder = jest.fn();
-rnvcore.logToSummary = jest.fn();
-rnvcore.logTask = jest.fn();
-rnvcore.logDefault = jest.fn();
-rnvcore.logDebug = jest.fn();
-rnvcore.logInfo = jest.fn();
-rnvcore.logError = jest.fn();
-rnvcore.logWarning = jest.fn();
-rnvcore.logSuccess = jest.fn();
-rnvcore.logSummary = jest.fn();
 rnvcore.chalk = () => _chalkMono;
-rnvcore.inquirerPrompt = jest.fn();
-rnvcore.getPlatformProjectDir = jest.fn();
-
 rnvcore.createRnvContext = (ctx?: Context) => {
     rnvcore.__MOCK_RNV_CONTEXT = generateContextDefaults(ctx);
 };
 rnvcore.getContext = () => rnvcore.__MOCK_RNV_CONTEXT;
-rnvcore.generateContextDefaults = generateContextDefaults;
-
-rnvcore.createRnvApi = () => {
-    global.MOCK_RNV_API = {
-        doResolve: jest.fn(),
-        getConfigProp: jest.fn(),
-        logger: jest.fn(),
-        analytics: {
-            captureEvent: () => {
-                //NOOP
-            },
-            captureException() {
-                //NOOP
-            },
-            teardown: async () => {
-                //NOOP
-            },
-        },
-        prompt: {
-            generateOptions() {
-                //NOOP
-                return {
-                    asString: '',
-                    keysAsArray: [],
-                    keysAsObject: {},
-                    optionsAsArray: [],
-                    valuesAsArray: [],
-                    valuesAsObject: {},
-                };
-            },
-            inquirerPrompt: async () => {
-                return {};
-            },
-            pressAnyKeyToContinue: async () => {
-                return {};
-            },
-            inquirerSeparator() {
-                return {};
-            },
-        },
-        spinner: jest.fn(),
-        fsExistsSync: jest.fn(),
-        fsReadFileSync: jest.fn(),
-        fsReaddirSync: jest.fn(),
-        fsWriteFileSync: jest.fn(),
-        path: jest.fn(),
-    };
-};
-
-rnvcore.getApi = () => {
-    return global.MOCK_RNV_API;
-};
 
 module.exports = rnvcore;

--- a/buildHooks/src/prePublish.ts
+++ b/buildHooks/src/prePublish.ts
@@ -29,6 +29,7 @@ const VERSIONED_PACKAGES = [
     'sdk-webos',
     'sdk-utils',
     'renative',
+    'integration-docker',
 ];
 
 type PackageConfig = {

--- a/packages/app-harness/package.json
+++ b/packages/app-harness/package.json
@@ -68,6 +68,7 @@
         "@rnv/engine-rn-next": "1.0.0-rc.12",
         "@rnv/engine-rn-tvos": "1.0.0-rc.12",
         "@rnv/engine-rn-web": "1.0.0-rc.12",
+        "@rnv/integration-starter": "1.0.0-rc.12",
         "@rnv/template-starter": "1.0.0-rc.12",
         "@types/react": "18.2.52",
         "@types/react-dom": "18.2.18",

--- a/packages/app-harness/renative.json
+++ b/packages/app-harness/renative.json
@@ -5,6 +5,9 @@
     "crypto": {
         "path": "./secrets/privateConfigs.enc"
     },
+    "integrations": {
+        "@rnv/integration-starter": {}
+    },
     "plugins": {
         "react-native-splash-screen": {
             "android": {
@@ -151,7 +154,10 @@
                 "templateXcode": {
                     "AppDelegate_h": {
                         "appDelegateExtensions": ["UNUserNotificationCenterDelegate"],
-                        "appDelegateImports": ["<UserNotifications/UNUserNotificationCenter.h>", "<UserNotifications/UserNotifications.h>"]
+                        "appDelegateImports": [
+                            "<UserNotifications/UNUserNotificationCenter.h>",
+                            "<UserNotifications/UserNotifications.h>"
+                        ]
                     },
                     "AppDelegate_mm": {
                         "appDelegateImports": ["<RNCPushNotificationIOS.h>"],

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -50,7 +50,7 @@ export const run = () => {
     // If the first argument is a flag, then the subCommand is missing
     // this occurs when rnv has to execute unknown commands (ie intergration commands)
     // commander does not handle this scenario automatically
-    if ((cmdOption && cmdOption.startsWith('--')) || cmdOption.startsWith('-')) {
+    if (cmdOption && (cmdOption.startsWith('--') || cmdOption.startsWith('-'))) {
         cmdOption = '';
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,7 +62,22 @@ export const run = () => {
         process.exit(0);
     });
 
-    executeRnv({ cmd: cmdValue, subCmd: cmdOption, program, process, spinner: Spinner, prompt: Prompt, logger: Logger })
+    // If the first argument is a flag, then the subCommand is missing
+    // this occurs when rnv has to execute unknown commands (ie intergration commands)
+    // commander does not handle this scenario automatically
+    if ((cmdOption && cmdOption.startsWith('--')) || cmdOption.startsWith('-')) {
+        cmdOption = '';
+    }
+
+    executeRnv({
+        cmd: cmdValue,
+        subCmd: cmdOption,
+        program,
+        process,
+        spinner: Spinner,
+        prompt: Prompt,
+        logger: Logger,
+    })
         .then(() => {
             logComplete(!getContext().runtime.keepSessionActive);
         })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import program from 'commander';
 import fs from 'fs';
 import path from 'path';
-import { logComplete, logError, getContext, RnvTaskOptionPresets } from '@rnv/core';
+import { logComplete, logError, getContext, RnvTaskOptionPresets, generateStringFromTaskOption } from '@rnv/core';
 import Spinner from './ora';
 import Prompt from './prompt';
 import Logger from './logger';
@@ -29,22 +29,7 @@ export const run = () => {
     program.version(packageJson.version, '-v, --version', 'output current version');
 
     RnvTaskOptionPresets.withAll().forEach((param) => {
-        let cmd = '';
-        if (param.shortcut) {
-            cmd += `-${param.shortcut}, `;
-        }
-        cmd += `--${param.key}`;
-
-        if (param.value) {
-            if (param.isRequired) {
-                cmd += ` <${param.value}>`;
-            } else if (param.variadic) {
-                cmd += ` [${param.value}...]`;
-            } else {
-                cmd += ` [${param.value}]`;
-            }
-        }
-        program.option(cmd, param.description);
+        program.option(generateStringFromTaskOption(param), param.description);
     });
 
     program.allowUnknownOption(true); // integration options are not known ahead of time

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -360,7 +360,10 @@ export const logTask = (task: string, customChalk?: string | RnvApiChalkFn) => {
         msg = `${currentChalk.green(`[task]${_getCurrentTask()}`)} ${task}${taskCount}`;
     }
 
-    // console.log(_sanitizePaths(msg));
+    if (_isInfoEnabled) {
+        // TODO: temporary. will be activated under different flag
+        console.log(_sanitizePaths(msg));
+    }
 };
 
 export const logDefault = (task: string, customChalk?: string | RnvApiChalkFn) => {
@@ -383,7 +386,10 @@ export const logDefault = (task: string, customChalk?: string | RnvApiChalkFn) =
         msg = `[log]${_getCurrentTask()} ${task} ${taskCount}`;
     }
 
-    // console.log(_sanitizePaths(msg));
+    if (_isInfoEnabled) {
+        // TODO: temporary. will be activated under different flag
+        console.log(_sanitizePaths(msg));
+    }
 };
 
 const getLogCounter = (task: string) => {

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -525,7 +525,7 @@ export const logSuccess = (msg: string) => {
             message: stripAnsi(_sanitizePaths(msg)),
         });
     }
-    logAndSave(currentChalk.magenta(`success:${_getCurrentTask()} ${_sanitizePaths(msg)}`));
+    logAndSave(currentChalk.magenta(`success: ${_getCurrentTask()} ${_sanitizePaths(msg)}`));
 };
 
 export const logError = (e: Error | string | unknown, isEnd = false, skipAnalytics = false) => {

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -559,9 +559,9 @@ export const logError = (e: Error | string | unknown, isEnd = false, skipAnalyti
             message: stripAnsi(_sanitizePaths(err)),
         });
     } else if (e && e instanceof Error && e.message) {
-        logAndSave(currentChalk.red(`error:${_getCurrentTask()} ${e.message}\n${e.stack}`), isEnd);
+        logAndSave(currentChalk.red(`error: ⨯ ${_getCurrentTask()} ${e.message}\n${e.stack}`), isEnd);
     } else {
-        logAndSave(currentChalk.red(`error:${_getCurrentTask()} ${e}`), isEnd);
+        logAndSave(currentChalk.red(`error: ⨯ ${_getCurrentTask()} ${e}`), isEnd);
     }
 
     ctx.runtime.keepSessionActive = false;

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -12,12 +12,17 @@ import {
 } from '@rnv/core';
 
 const ICN_ROCKET = isSystemWin ? 'RNV' : '🚀';
-const ICN_UNICORN = isSystemWin ? 'unicorn' : '🦄';
+// const ICN_UNICORN = isSystemWin ? 'unicorn' : '🦄';
 const _chalkCols = generateDefaultChalk();
 const _chalkMono = {
     ..._chalkCols,
 };
+
+const colorBlue = { r: 10, g: 116, b: 230 }; // '#0a74e6'
+
 let currentChalk: RnvApiChalk = _chalk;
+let chalkBlue: any = _chalk.rgb(colorBlue.r, colorBlue.g, colorBlue.b);
+
 let RNV = 'ReNative';
 const PRIVATE_PARAMS = ['-k', '--key'];
 let _currentProcess: NodeJS.Process;
@@ -44,6 +49,7 @@ export const logInitialize = () => {
 
     if (ctx.program.mono) {
         currentChalk = _chalkMono;
+        chalkBlue = _chalkMono;
     }
     _updateDefaultColors();
     RNV = getCurrentCommand();
@@ -52,17 +58,16 @@ export const logInitialize = () => {
 
 export const logWelcome = () => {
     const ctx = getContext();
-    const chalCol = currentChalk.rgb(10, 116, 230);
     const shortLen = 64;
     // prettier-ignore
     let str = _defaultColor(`
 ┌─────────────────────────────────────────────────────────────────┐
-│ ${chalCol('██████╗')} ███████╗${chalCol('███╗   ██╗')} █████╗ ████████╗██╗${chalCol('██╗   ██╗')}███████╗ │
-│ ${chalCol('██╔══██╗')}██╔════╝${chalCol('████╗  ██║')}██╔══██╗╚══██╔══╝██║${chalCol('██║   ██║')}██╔════╝ │
-│ ${chalCol('██████╔╝')}█████╗  ${chalCol('██╔██╗ ██║')}███████║   ██║   ██║${chalCol('██║   ██║')}█████╗   │
-│ ${chalCol('██╔══██╗')}██╔══╝  ${chalCol('██║╚██╗██║')}██╔══██║   ██║   ██║${chalCol('╚██╗ ██╔╝')}██╔══╝   │
-│ ${chalCol('██║  ██║')}███████╗${chalCol('██║ ╚████║')}██║  ██║   ██║   ██║${chalCol(' ╚████╔╝ ')}███████╗ │
-│ ${chalCol('╚═╝  ╚═╝')}╚══════╝${chalCol('╚═╝  ╚═══╝')}╚═╝  ╚═╝   ╚═╝   ╚═╝${chalCol('  ╚═══╝  ')}╚══════╝ │
+│ ${chalkBlue('██████╗')} ███████╗${chalkBlue('███╗   ██╗')} █████╗ ████████╗██╗${chalkBlue('██╗   ██╗')}███████╗ │
+│ ${chalkBlue('██╔══██╗')}██╔════╝${chalkBlue('████╗  ██║')}██╔══██╗╚══██╔══╝██║${chalkBlue('██║   ██║')}██╔════╝ │
+│ ${chalkBlue('██████╔╝')}█████╗  ${chalkBlue('██╔██╗ ██║')}███████║   ██║   ██║${chalkBlue('██║   ██║')}█████╗   │
+│ ${chalkBlue('██╔══██╗')}██╔══╝  ${chalkBlue('██║╚██╗██║')}██╔══██║   ██║   ██║${chalkBlue('╚██╗ ██╔╝')}██╔══╝   │
+│ ${chalkBlue('██║  ██║')}███████╗${chalkBlue('██║ ╚████║')}██║  ██║   ██║   ██║${chalkBlue(' ╚████╔╝ ')}███████╗ │
+│ ${chalkBlue('╚═╝  ╚═╝')}╚══════╝${chalkBlue('╚═╝  ╚═══╝')}╚═╝  ╚═╝   ╚═╝   ╚═╝${chalkBlue('  ╚═══╝  ')}╚══════╝ │
 `);
 
     if (ctx.files?.rnv?.package?.version) {
@@ -208,7 +213,7 @@ export const logSummary = (header = 'SUMMARY') => {
         logAndSave(chalk().white('npx ' + getCurrentCommand(true)), true);
     }
 
-    let logContent = printIntoBox(`All good as ${ICN_UNICORN} `);
+    let logContent = ''; //= printIntoBox(`All good as ${ICN_UNICORN} `);
     if (ctx.logMessages && ctx.logMessages.length) {
         logContent = '';
         ctx.logMessages.forEach((m) => {
@@ -220,9 +225,14 @@ export const logSummary = (header = 'SUMMARY') => {
     ctx.timeEnd = new Date();
     timeString = `| ${ctx.timeEnd.toLocaleString()}`;
 
-    let str = printBoxStart(`${ICN_ROCKET}  ${header} ${timeString}`, getCurrentCommand());
+    // let envString = '';
+    // if (ctx.process) {
+    //     envString = `${ctx.process.platform} | ${ctx.process.arch} | node v${ctx.process.versions?.node}`;
+    // }
 
-    str += printIntoBox(`ReNative Version: ${_highlightColor(ctx.rnvVersion)}`);
+    let str = printBoxStart(`${header} ${timeString} | rnv@${ctx.rnvVersion}`, getCurrentCommand());
+
+    // str += printIntoBox(`ReNative Version: ${_highlightColor(ctx.rnvVersion)}`);
     if (ctx.files?.project?.package?.name && ctx.files?.project?.package?.version) {
         str += printIntoBox(`Project Name ($package.name): ${_highlightColor(ctx.files.project.package.name)}`);
         str += printIntoBox(
@@ -280,7 +290,7 @@ export const logSummary = (header = 'SUMMARY') => {
         str += printIntoBox(`Executed Time: ${_msToTime(ctx.timeEnd.getTime() - ctx.timeStart.getTime())}`);
     }
 
-    str += printIntoBox('');
+    // str += printIntoBox('');
 
     str += logContent.replace(/\n\s*\n\s*\n/g, '\n\n');
 
@@ -308,7 +318,7 @@ const _msToTime = (seconds: number) => {
 
 const _getCurrentTask = () => {
     const ctx = getContext();
-    return ctx._currentTask ? currentChalk.grey(` [${ctx._currentTask}]`) : '';
+    return ctx._currentTask ? currentChalk.grey(` ○ ${ctx._currentTask}:`) : '';
 };
 
 const _sanitizePaths = (msg: string) => {
@@ -341,22 +351,20 @@ export const logTask = (task: string, customChalk?: string | RnvApiChalkFn) => {
 
     let msg = '';
     if (typeof customChalk === 'string') {
-        msg = `${currentChalk.green(`[ task ]${_getCurrentTask()}`)} ${task}${taskCount} ${currentChalk.grey(
+        msg = `${currentChalk.green(`[task]${_getCurrentTask()}`)} ${task}${taskCount} ${currentChalk.grey(
             customChalk
         )}`;
     } else if (customChalk) {
-        msg = customChalk(`[ task ]${_getCurrentTask()} ${task}${taskCount}`);
+        msg = customChalk(`[task]${_getCurrentTask()} ${task}${taskCount}`);
     } else {
-        msg = `${currentChalk.green(`[ task ]${_getCurrentTask()}`)} ${task}${taskCount}`;
+        msg = `${currentChalk.green(`[task]${_getCurrentTask()}`)} ${task}${taskCount}`;
     }
 
-    console.log(_sanitizePaths(msg));
+    // console.log(_sanitizePaths(msg));
 };
 
 export const logDefault = (task: string, customChalk?: string | RnvApiChalkFn) => {
-    if (!TASK_COUNTER[task]) TASK_COUNTER[task] = 0;
-    TASK_COUNTER[task] += 1;
-    const taskCount = currentChalk.grey(`[${TASK_COUNTER[task]}]`);
+    const taskCount = getLogCounter(task);
 
     if (_jsonOnly) {
         return _printJson({
@@ -368,17 +376,26 @@ export const logDefault = (task: string, customChalk?: string | RnvApiChalkFn) =
 
     let msg = '';
     if (typeof customChalk === 'string') {
-        msg = `[ log ]${_getCurrentTask()} ${task}${taskCount} ${currentChalk.grey(customChalk)}`;
+        msg = `[log]${_getCurrentTask()} ${task}${taskCount} ${currentChalk.grey(customChalk)}`;
     } else if (customChalk) {
-        msg = customChalk(`[ log ]${_getCurrentTask()} ${task}${taskCount}`);
+        msg = customChalk(`[log]${_getCurrentTask()} ${task} ${taskCount}`);
     } else {
-        msg = `[ log ]${_getCurrentTask()} ${task}${taskCount}`;
+        msg = `[log]${_getCurrentTask()} ${task} ${taskCount}`;
     }
 
-    console.log(_sanitizePaths(msg));
+    // console.log(_sanitizePaths(msg));
+};
+
+const getLogCounter = (task: string) => {
+    if (!TASK_COUNTER[task]) TASK_COUNTER[task] = 0;
+    TASK_COUNTER[task] += 1;
+    const taskCount = currentChalk.grey(`[${TASK_COUNTER[task]}]`);
+    return taskCount;
 };
 
 export const logInitTask = (task: string, customChalk?: string | ((s: string) => string)) => {
+    const taskCount = getLogCounter(task);
+
     if (_jsonOnly) {
         return _printJson({
             type: 'taskInit',
@@ -388,11 +405,11 @@ export const logInitTask = (task: string, customChalk?: string | ((s: string) =>
     }
     let msg = '';
     if (typeof customChalk === 'string') {
-        msg = `${currentChalk.rgb(183, 84, 117)(`[ task ] ${task}`)} ${currentChalk.grey(customChalk)}`;
+        msg = `${chalkBlue(`task: ○ ${task}`)} ${customChalk} ${taskCount}`;
     } else if (customChalk) {
-        msg = customChalk(`[ task ] ${task}`);
+        msg = customChalk(`task ○ ${task} ${taskCount}`);
     } else {
-        msg = currentChalk.rgb(183, 84, 117)(`[ task ] ${task}`);
+        msg = `${chalkBlue('task:')} ○ ${task} ${taskCount}`;
     }
 
     console.log(msg);
@@ -414,13 +431,17 @@ export const logExitTask = (task: string, customChalk?: (s: string) => string) =
             message: stripAnsi(_sanitizePaths(typeof customChalk === 'string' ? customChalk : task)),
         });
     }
+    const taskCount = getLogCounter(task);
+
     let msg = '';
     if (typeof customChalk === 'string') {
-        msg = `${currentChalk.rgb(183, 84, 117)(`[ task ] ${task}`)} ${currentChalk.grey(customChalk)}`;
+        msg = `${currentChalk.green(`task: < ${task}`)} ${currentChalk.grey(
+            customChalk
+        )}${taskCount} ${currentChalk.green('✔')}`;
     } else if (customChalk) {
-        msg = customChalk(`[ task ] ${task}`);
+        msg = customChalk(`task: < ${task} ${taskCount} ${currentChalk.green('✔')}`);
     } else {
-        msg = currentChalk.rgb(183, 84, 117)(`[ task ] ${task}`);
+        msg = `${currentChalk.green('task:')} ${currentChalk.green('✔')} ${task} ${taskCount}`;
     }
 
     console.log(msg);
@@ -432,11 +453,7 @@ export const logHook = (hook = '', msg = '') => {
         if (_getCurrentTask()) payload.task = stripAnsi(_getCurrentTask());
         return _printJson(payload);
     }
-    console.log(
-        `${currentChalk.rgb(127, 255, 212)(`[ hook ]${_getCurrentTask()} ${hook}`)} ${currentChalk.grey(
-            _sanitizePaths(msg)
-        )}`
-    );
+    console.log(`${`[hook]`} ${_sanitizePaths(msg)}`);
 };
 
 export const logWarning = (msg: string | boolean | unknown) => {
@@ -449,7 +466,7 @@ export const logWarning = (msg: string | boolean | unknown) => {
             message: stripAnsi(msgSn),
         });
     }
-    logAndSave(currentChalk.yellow(`[ warn ]${_getCurrentTask()} ${msgSn}`));
+    logAndSave(currentChalk.yellow(`[warn]${_getCurrentTask()} ${msgSn}`));
 };
 
 export const logInfo = (msg: string) => {
@@ -461,7 +478,7 @@ export const logInfo = (msg: string) => {
             message: stripAnsi(_sanitizePaths(msg)),
         });
     }
-    console.log(currentChalk.cyan(`[ info ]${_getCurrentTask()} ${_sanitizePaths(msg)}`));
+    console.log(`${currentChalk.cyan('info:')}${_getCurrentTask()} ${_sanitizePaths(msg)}`);
 };
 
 export const logDebug = (...args: Array<string>) => {
@@ -490,7 +507,7 @@ export const isInfoEnabled = () => _isInfoEnabled;
 
 export const logComplete = (isEnd = false) => {
     if (_jsonOnly) return;
-    console.log(currentChalk.bold.white(`\n ${RNV} - Done! ${ICN_ROCKET}`));
+    console.log(currentChalk.bold(`${RNV} - Done! ${ICN_ROCKET}`));
     if (isEnd) logEnd(0);
 };
 
@@ -502,7 +519,7 @@ export const logSuccess = (msg: string) => {
             message: stripAnsi(_sanitizePaths(msg)),
         });
     }
-    logAndSave(currentChalk.magenta(`[ success ]${_getCurrentTask()} ${_sanitizePaths(msg)}`));
+    logAndSave(currentChalk.magenta(`[success]${_getCurrentTask()} ${_sanitizePaths(msg)}`));
 };
 
 export const logError = (e: Error | string | unknown, isEnd = false, skipAnalytics = false) => {
@@ -536,9 +553,9 @@ export const logError = (e: Error | string | unknown, isEnd = false, skipAnalyti
             message: stripAnsi(_sanitizePaths(err)),
         });
     } else if (e && e instanceof Error && e.message) {
-        logAndSave(currentChalk.red(`[ error ]${_getCurrentTask()} ${e.message}\n${e.stack}`), isEnd);
+        logAndSave(currentChalk.red(`[error]${_getCurrentTask()} ${e.message}\n${e.stack}`), isEnd);
     } else {
-        logAndSave(currentChalk.red(`[ error ]${_getCurrentTask()} ${e}`), isEnd);
+        logAndSave(currentChalk.red(`[error]${_getCurrentTask()} ${e}`), isEnd);
     }
 
     ctx.runtime.keepSessionActive = false;

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -30,7 +30,7 @@ let _isInfoEnabled = false;
 let _infoFilter: Array<string> = [];
 // let _c: RnvContext;
 // let _isMono = false;
-let _defaultColor = _chalkCols.white;
+let _defaultColor: any = _chalkCols.white;
 let _highlightColor = _chalkCols.white;
 // let _analytics: AnalyticsApi;
 let _jsonOnly: boolean;
@@ -73,21 +73,23 @@ export const logWelcome = () => {
     if (ctx.files?.rnv?.package?.version) {
         ctx.rnvVersion = ctx.files.rnv.package.version;
         str += printIntoBox(
-            `Version: ${currentChalk.green(ctx.rnvVersion)} ${ICN_ROCKET} ${currentChalk.yellow('Firing up!...')}`,
+            currentChalk.grey(
+                `${ICN_ROCKET} v:${ctx.rnvVersion} | ${'renative.org'} | ${ctx.timeStart.toLocaleString()}`
+            ),
             shortLen
         );
         if (ctx.rnvVersion?.includes?.('alpha')) {
             str += printIntoBox(`${currentChalk.yellow('WARNING: this is a prerelease version.')}`, shortLen);
         }
     }
-    str += printIntoBox(
-        `${currentChalk.grey('https://renative.org')} | Start Time: ${currentChalk.grey(
-            ctx.timeStart.toLocaleString()
-        )}`,
-        shortLen
-    );
+    // str += printIntoBox(
+    //     `${currentChalk.grey('https://renative.org')} | Start Time: ${currentChalk.grey(
+    //         ctx.timeStart.toLocaleString()
+    //     )}`,
+    //     shortLen
+    // );
     // str += printIntoBox(`      ${ICN_ROCKET} ${currentChalk.yellow('Firing up!...')}`);
-    str += printIntoBox(`$ ${currentChalk.cyan(getCurrentCommand(true))}`, shortLen);
+    str += printIntoBox(`$ ${currentChalk.bold(getCurrentCommand(true))}`, shortLen);
     if (ctx.timeStart) {
         // str += printIntoBox(`      Start Time: ${currentChalk.grey(ctx.timeStart.toLocaleString())}`);
     }
@@ -142,8 +144,8 @@ export function stripAnsi(string: string) {
 // };
 
 const _updateDefaultColors = () => {
-    _defaultColor = currentChalk.gray;
-    _highlightColor = currentChalk.green;
+    _defaultColor = currentChalk;
+    _highlightColor = currentChalk.bold; //currentChalk.bold;
 };
 _updateDefaultColors();
 
@@ -210,7 +212,7 @@ export const logSummary = (header = 'SUMMARY') => {
         logAndSave(chalk().yellow('You are trying to run global rnv command in your current project.'), true);
         logAndSave(chalk().yellow('This might lead to unexpected behaviour.'), true);
         logAndSave(chalk().yellow('Run your rnv command with npx prefix:'), true);
-        logAndSave(chalk().white('npx ' + getCurrentCommand(true)), true);
+        logAndSave(chalk().bold('npx ' + getCurrentCommand(true)), true);
     }
 
     let logContent = ''; //= printIntoBox(`All good as ${ICN_UNICORN} `);
@@ -230,7 +232,10 @@ export const logSummary = (header = 'SUMMARY') => {
     //     envString = `${ctx.process.platform} | ${ctx.process.arch} | node v${ctx.process.versions?.node}`;
     // }
 
-    let str = printBoxStart(`${header} ${timeString} | rnv@${ctx.rnvVersion}`, getCurrentCommand());
+    let str = printBoxStart(
+        `${currentChalk.green.bold(header)} ${timeString} | rnv@${ctx.rnvVersion}`,
+        getCurrentCommand()
+    );
 
     // str += printIntoBox(`ReNative Version: ${_highlightColor(ctx.rnvVersion)}`);
     if (ctx.files?.project?.package?.name && ctx.files?.project?.package?.version) {
@@ -392,9 +397,12 @@ export const logDefault = (task: string, customChalk?: string | RnvApiChalkFn) =
     }
 };
 
-const getLogCounter = (task: string) => {
+const getLogCounter = (task: string, skipAddition = false) => {
     if (!TASK_COUNTER[task]) TASK_COUNTER[task] = 0;
-    TASK_COUNTER[task] += 1;
+    if (!skipAddition) {
+        TASK_COUNTER[task] += 1;
+    }
+
     const taskCount = currentChalk.grey(`[${TASK_COUNTER[task]}]`);
     return taskCount;
 };
@@ -411,11 +419,11 @@ export const logInitTask = (task: string, customChalk?: string | ((s: string) =>
     }
     let msg = '';
     if (typeof customChalk === 'string') {
-        msg = `${chalkBlue(`task: ○ ${task}`)} ${customChalk} ${taskCount}`;
+        msg = `${chalkBlue().bold(`task: ○ ${task}`)} ${customChalk} ${taskCount}`;
     } else if (customChalk) {
         msg = customChalk(`task ○ ${task} ${taskCount}`);
     } else {
-        msg = `${chalkBlue('task:')} ○ ${task} ${taskCount}`;
+        msg = `${chalkBlue.bold('task:')} ○ ${task} ${taskCount}`;
     }
 
     console.log(msg);
@@ -437,7 +445,7 @@ export const logExitTask = (task: string, customChalk?: (s: string) => string) =
             message: stripAnsi(_sanitizePaths(typeof customChalk === 'string' ? customChalk : task)),
         });
     }
-    const taskCount = getLogCounter(task);
+    const taskCount = getLogCounter(task, true);
 
     let msg = '';
     if (typeof customChalk === 'string') {
@@ -472,7 +480,7 @@ export const logWarning = (msg: string | boolean | unknown) => {
             message: stripAnsi(msgSn),
         });
     }
-    logAndSave(currentChalk.yellow(`[warn]${_getCurrentTask()} ${msgSn}`));
+    logAndSave(currentChalk.yellow(`warn:${_getCurrentTask()} ${msgSn}`));
 };
 
 export const logInfo = (msg: string) => {
@@ -525,7 +533,7 @@ export const logSuccess = (msg: string) => {
             message: stripAnsi(_sanitizePaths(msg)),
         });
     }
-    logAndSave(currentChalk.magenta(`[success]${_getCurrentTask()} ${_sanitizePaths(msg)}`));
+    logAndSave(currentChalk.magenta(`success:${_getCurrentTask()} ${_sanitizePaths(msg)}`));
 };
 
 export const logError = (e: Error | string | unknown, isEnd = false, skipAnalytics = false) => {
@@ -559,9 +567,9 @@ export const logError = (e: Error | string | unknown, isEnd = false, skipAnalyti
             message: stripAnsi(_sanitizePaths(err)),
         });
     } else if (e && e instanceof Error && e.message) {
-        logAndSave(currentChalk.red(`[error]${_getCurrentTask()} ${e.message}\n${e.stack}`), isEnd);
+        logAndSave(currentChalk.red(`error:${_getCurrentTask()} ${e.message}\n${e.stack}`), isEnd);
     } else {
-        logAndSave(currentChalk.red(`[error]${_getCurrentTask()} ${e}`), isEnd);
+        logAndSave(currentChalk.red(`error:${_getCurrentTask()} ${e}`), isEnd);
     }
 
     ctx.runtime.keepSessionActive = false;
@@ -583,7 +591,7 @@ export const logEnd = (code: number) => {
 
 export const logAppInfo = (c: RnvContext) => {
     if (!_jsonOnly) {
-        logInfo(`Current App Config: ${currentChalk.bold.white(c.runtime.appId)}`);
+        logInfo(`Current App Config: ${currentChalk.bold(c.runtime.appId)}`);
     }
 };
 

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -525,7 +525,7 @@ export const logSuccess = (msg: string) => {
             message: stripAnsi(_sanitizePaths(msg)),
         });
     }
-    logAndSave(currentChalk.magenta(`success: ${_getCurrentTask()} ${_sanitizePaths(msg)}`));
+    logAndSave(`${currentChalk.magenta(`info: ✔`)} ${_sanitizePaths(msg)}`);
 };
 
 export const logError = (e: Error | string | unknown, isEnd = false, skipAnalytics = false) => {

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -23,7 +23,7 @@ const colorBlue = { r: 10, g: 116, b: 230 }; // '#0a74e6'
 let currentChalk: RnvApiChalk = _chalk;
 let chalkBlue: any = _chalk.rgb(colorBlue.r, colorBlue.g, colorBlue.b);
 
-let RNV = 'ReNative';
+// const RNV = 'ReNative';
 const PRIVATE_PARAMS = ['-k', '--key'];
 let _currentProcess: NodeJS.Process;
 let _isInfoEnabled = false;
@@ -52,7 +52,7 @@ export const logInitialize = () => {
         chalkBlue = _chalkMono;
     }
     _updateDefaultColors();
-    RNV = getCurrentCommand();
+    // RNV = getCurrentCommand();
     if (!_jsonOnly) logWelcome();
 };
 
@@ -203,7 +203,7 @@ export const logRaw = (...args: Array<string>) => {
     console.log.apply(null, args);
 };
 
-export const logSummary = (header = 'SUMMARY') => {
+export const logSummary = (header = '✔ SUMMARY') => {
     const ctx = getContext();
 
     if (_jsonOnly) return;
@@ -513,7 +513,7 @@ export const isInfoEnabled = () => _isInfoEnabled;
 
 export const logComplete = (isEnd = false) => {
     if (_jsonOnly) return;
-    console.log(currentChalk.bold(`${RNV} - Done! ${ICN_ROCKET}`));
+    // console.log(currentChalk.green.bold(`✔ Done`));
     if (isEnd) logEnd(0);
 };
 

--- a/packages/core/src/buildHooks/index.ts
+++ b/packages/core/src/buildHooks/index.ts
@@ -8,7 +8,7 @@ import { inquirerPrompt } from '../api';
 import { getConfigProp } from '../context/contextProps';
 
 export const executePipe = async (c: RnvContext, key: string) => {
-    logHook('executePipe', c?.program?.json ? key : `('${key}')`);
+    logDebug('executePipe', c?.program?.json ? key : `('${key}')`);
 
     await buildHooks(c);
 
@@ -91,7 +91,7 @@ export const buildHooks = async (c: RnvContext) => {
             ? c.paths.buildHooks.src.indexTs
             : c.paths.buildHooks.src.index;
         try {
-            logHook('buildHooks', 'Build hooks not complied. BUILDING...');
+            logInfo('Build hooks not complied. BUILDING...');
 
             await build({
                 entryPoints: [indexPath],

--- a/packages/core/src/configs/templates.ts
+++ b/packages/core/src/configs/templates.ts
@@ -9,7 +9,7 @@ export const checkIfTemplateConfigured = async (c: RnvContext) => {
     if (c.program.skipDependencyCheck || c.files.project.config?.isTemplate) return true;
     if (!c.buildConfig.templates) {
         logWarning(
-            `Your ${chalk().white(c.paths.project.config)} does not contain ${chalk().white(
+            `Your ${chalk().bold(c.paths.project.config)} does not contain ${chalk().bold(
                 'templates'
             )} object. ReNative will skip template generation`
         );
@@ -19,14 +19,14 @@ export const checkIfTemplateConfigured = async (c: RnvContext) => {
         const obj = c.buildConfig.templates?.[k] || { version: 'unknown template version' };
         if (!doResolve(k, false, { basedir: '../' }) && !doResolve(k, false)) {
             logInfo(
-                `Your ${chalk().white(`${k}@${obj.version}`)} template is missing in renative.json. CONFIGURING...DONE`
+                `Your ${chalk().bold(`${k}@${obj.version}`)} template is missing in renative.json. CONFIGURING...DONE`
             );
             c._requiresNpmInstall = true;
             c.runtime.requiresBootstrap = true;
         }
         if (c.files.project.package.devDependencies) {
             if (c.files.project.package.devDependencies[k] !== obj.version) {
-                logInfo(`Updating template ${chalk().white(`${k}`)} => ${chalk().green(obj.version)}. ...DONE`);
+                logInfo(`Updating template ${chalk().bold(`${k}`)} => ${chalk().green(obj.version)}. ...DONE`);
             }
 
             c.files.project.package.devDependencies[k] = obj.version;

--- a/packages/core/src/configs/workspaces.ts
+++ b/packages/core/src/configs/workspaces.ts
@@ -52,11 +52,11 @@ export const getWorkspaceDirPath = async (c: RnvContext) => {
                     const { conf } = await inquirerPrompt({
                         name: 'conf',
                         type: 'confirm',
-                        message: `Your project belongs to workspace ${chalk().white(
+                        message: `Your project belongs to workspace ${chalk().bold(
                             ws
-                        )}. do you want to add new workspace ${chalk().white(
-                            ws
-                        )} to your local system at ${chalk().white(wsDir)}?`,
+                        )}. do you want to add new workspace ${chalk().bold(ws)} to your local system at ${chalk().bold(
+                            wsDir
+                        )}?`,
                         warningMessage: 'No app configs found for this project',
                     });
                     confirm = conf;

--- a/packages/core/src/context/contextProps.ts
+++ b/packages/core/src/context/contextProps.ts
@@ -122,7 +122,7 @@ export const getAppConfigBuildsFolder = (c: RnvContext, platform: RnvPlatform, c
     const pp = customPath || c.paths.appConfig.dir;
     if (!pp) {
         logWarning(
-            `getAppConfigBuildsFolder: Path ${chalk().white(
+            `getAppConfigBuildsFolder: Path ${chalk().bold(
                 'c.paths.appConfig.dir'
             )} not defined! can't return path. You might not be in renative project`
         );

--- a/packages/core/src/engines/index.ts
+++ b/packages/core/src/engines/index.ts
@@ -190,9 +190,9 @@ export const loadEnginePluginDeps = async (c: RnvContext, engineConfigs: Array<R
         const addedPluginsKeys = Object.keys(addedPlugins);
 
         logInfo(
-            `Engines: ${chalk().yellow(engineKeys.join(','))} require plugins ${chalk().white(
+            `Engines: ${chalk().yellow(engineKeys.join(','))} require plugins ${chalk().bold(
                 addedPluginsKeys.join(',')
-            )} to be added to ${chalk().white(c.paths.project.config)}`
+            )} to be added to ${chalk().bold(c.paths.project.config)}`
         );
         const confirm = await inquirerPrompt({
             name: 'selectedScheme',
@@ -548,7 +548,7 @@ export const getEngineRunner = (c: RnvContext, task: string, customTasks?: RnvTa
     if (hasEngineTask(task, c.runtime.enginesById[ENGINE_CORE].tasks, configExists)) {
         return c.runtime.enginesById[ENGINE_CORE];
     }
-    if (failOnMissingEngine) throw new Error(`Cound not find suitable executor for task ${chalk().white(task)}`);
+    if (failOnMissingEngine) throw new Error(`Cound not find suitable executor for task ${chalk().bold(task)}`);
     return undefined;
 };
 

--- a/packages/core/src/formatter/index.ts
+++ b/packages/core/src/formatter/index.ts
@@ -60,7 +60,7 @@ const checkForDuplicates = (arr: Array<any>) => {
         if (v) {
             Object.keys(v).forEach((k) => {
                 if (dupCheck[k]) {
-                    logWarning(`Key ${chalk().white(k)} is duplicated in your package.json`);
+                    logWarning(`Key ${chalk().bold(k)} is duplicated in your package.json`);
                 }
                 dupCheck[k] = true;
             });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,3 +67,4 @@ export * from './system/types';
 export * from './api/types';
 export * from './types';
 export * from './schema/types';
+export * from './integrations/types';

--- a/packages/core/src/logger/index.ts
+++ b/packages/core/src/logger/index.ts
@@ -22,8 +22,7 @@ export const logTask: RnvApiLogger['logTask'] = (task, customChalk?) => getApi()
 export const logDefault: RnvApiLogger['logDefault'] = (msg, customChalk?) =>
     getApi().logger.logDefault(msg, customChalk);
 
-export const logInitTask: RnvApiLogger['logInitTask'] = (task, customChalk?) =>
-    getApi().logger.logInitTask(task, customChalk);
+export const logInitTask: RnvApiLogger['logInitTask'] = (task) => getApi().logger.logInitTask(task);
 
 export const logExitTask: RnvApiLogger['logExitTask'] = (task, customChalk?) =>
     getApi().logger.logExitTask(task, customChalk);

--- a/packages/core/src/platforms/index.ts
+++ b/packages/core/src/platforms/index.ts
@@ -11,7 +11,7 @@ import { doResolve } from '../system/resolve';
 
 export const logErrorPlatform = (c: RnvContext) => {
     logError(
-        `Platform: ${chalk().white(c.platform)} doesn't support command: ${chalk().white(c.command)}`,
+        `Platform: ${chalk().bold(c.platform)} doesn't support command: ${chalk().bold(c.command)}`,
         true // kill it if we're not supporting this
     );
     return false;
@@ -157,7 +157,7 @@ export const isPlatformSupportedSync = (
         if (reject) {
             reject(
                 chalk().red(
-                    `Platform ${platform} is not supported. Use one of the following: ${chalk().white(
+                    `Platform ${platform} is not supported. Use one of the following: ${chalk().bold(
                         c.runtime.availablePlatforms.join(', ')
                     )} .`
                 )
@@ -172,7 +172,7 @@ export const isPlatformSupportedSync = (
 export const isPlatformActive = (c: RnvContext, platform: RnvPlatform, resolve?: () => void) => {
     if (!c.buildConfig || !c.buildConfig.platforms) {
         logError(
-            `Your appConfigFile is not configured properly! check ${chalk().white(c.paths.appConfig.config)} location.`
+            `Your appConfigFile is not configured properly! check ${chalk().bold(c.paths.appConfig.config)} location.`
         );
         if (resolve) resolve();
         return false;

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -685,7 +685,6 @@ const _overridePlugin = (c: RnvContext, pluginsPath: string, dir: string) => {
     }
 
     // const parentDest = path.join(dir, '..')
-    // console.log('SKSLSL', dir, dest);
 };
 
 export const overrideFileContents = (dest: string, override: Record<string, string>, overridePath = '') => {

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -193,9 +193,9 @@ export const configurePlugins = async (c: RnvContext) => {
                 // Skip Warning as this is intentional "plugin":null
             } else {
                 logWarning(
-                    `Plugin with name ${chalk().white(
+                    `Plugin with name ${chalk().bold(
                         k
-                    )} does not exists in ReNative source:rnv scope. you need to define it manually here: ${chalk().white(
+                    )} does not exists in ReNative source:rnv scope. you need to define it manually here: ${chalk().bold(
                         c.paths.project.builds.config
                     )}`
                 );
@@ -208,9 +208,9 @@ export const configurePlugins = async (c: RnvContext) => {
                     }
                 } else if (dependencies[k] !== plugin.version) {
                     logWarning(
-                        `Version mismatch of dependency ${chalk().white(k)} between:
-${chalk().white(c.paths.project.package)}: v(${chalk().red(dependencies[k])}) and
-${chalk().white(c.paths.project.builds.config)}: v(${chalk().green(plugin.version)}).
+                        `Version mismatch of dependency ${chalk().bold(k)} between:
+${chalk().bold(c.paths.project.package)}: v(${chalk().red(dependencies[k])}) and
+${chalk().bold(c.paths.project.builds.config)}: v(${chalk().green(plugin.version)}).
 ${ovMsg}`
                     );
 
@@ -226,7 +226,7 @@ ${ovMsg}`
                     }
                 } else if (devDependencies[k] !== plugin.version) {
                     logWarning(
-                        `Version mismatch of devDependency ${chalk().white(k)} between package.json: v(${chalk().red(
+                        `Version mismatch of devDependency ${chalk().bold(k)} between package.json: v(${chalk().red(
                             devDependencies[k]
                         )}) and plugins.json: v(${chalk().red(plugin.version)}). ${ovMsg}`
                     );
@@ -238,7 +238,7 @@ ${ovMsg}`
             // Dependency does not exists
             if (plugin.version) {
                 logInfo(
-                    `Missing dependency ${chalk().white(k)} v(${chalk().red(plugin.version)}) in package.json. ${ovMsg}`
+                    `Missing dependency ${chalk().bold(k)} v(${chalk().red(plugin.version)}) in package.json. ${ovMsg}`
                 );
 
                 hasPackageChanged = true;
@@ -259,14 +259,14 @@ ${ovMsg}`
 - ${k} .npm sub dependencies:
    |- ${npmKey}@${chalk().red(npmDep)}`);
                 } else if (!dependencies[npmKey]) {
-                    logInfo(`Plugin ${chalk().white(k)} requires npm dependency ${chalk().white(npmKey)}. ${ovMsg}`);
+                    logInfo(`Plugin ${chalk().bold(k)} requires npm dependency ${chalk().bold(npmKey)}. ${ovMsg}`);
                     if (npmDep) {
                         _applyPackageDependency(newDeps, npmKey, npmDep);
                         hasPackageChanged = true;
                     }
                 } else if (dependencies[npmKey] !== npmDep) {
                     logWarning(
-                        `Plugin ${chalk().white(k)} npm dependency ${chalk().white(npmKey)} mismatch (${chalk().red(
+                        `Plugin ${chalk().bold(k)} npm dependency ${chalk().bold(npmKey)} mismatch (${chalk().red(
                             dependencies[npmKey]
                         )}) => (${chalk().green(npmDep)}) .${ovMsg}`
                     );
@@ -336,7 +336,7 @@ const _resolvePluginDependencies = async (
             const { confirm } = await inquirerPrompt({
                 type: 'confirm',
                 message: `Install ${key}?`,
-                warningMessage: `Plugin ${chalk().white(key)} source:${chalk().white(scope)} required by ${chalk().red(
+                warningMessage: `Plugin ${chalk().bold(key)} source:${chalk().bold(scope)} required by ${chalk().red(
                     parentKey
                 )} is not installed`,
             });
@@ -348,7 +348,7 @@ const _resolvePluginDependencies = async (
             }
         } else {
             logWarning(
-                `Plugin ${chalk().white(parentKey)} requires ${chalk().red(key)} which is not available in your system`
+                `Plugin ${chalk().bold(parentKey)} requires ${chalk().red(key)} which is not available in your system`
             );
         }
     } else {
@@ -443,17 +443,17 @@ export const parsePlugins = (
                 // Not valid warning as web based plugins might not need web definition object to work
                 // if (totalIncludedPlugins === 0) {
                 //     logWarning(
-                //         `Found plugins in your app but non are included. are you sure you added ${chalk().white('includedPlugins')} in your renative.json config?`
+                //         `Found plugins in your app but non are included. are you sure you added ${chalk().bold('includedPlugins')} in your renative.json config?`
                 //     );
                 // }
             } else {
-                logError(`You have no plugins defined in ${chalk().white(c.paths.project.builds.config)}`);
+                logError(`You have no plugins defined in ${chalk().bold(c.paths.project.builds.config)}`);
             }
         } else {
             logWarning(
-                `You haven't included any ${chalk().white(
-                    '{ common: { includedPlugins: [] }}'
-                )} in your ${chalk().white(c.paths.appConfig.config)}. Your app might not work correctly`
+                `You haven't included any ${chalk().bold('{ common: { includedPlugins: [] }}')} in your ${chalk().bold(
+                    c.paths.appConfig.config
+                )}. Your app might not work correctly`
             );
         }
     }
@@ -475,7 +475,7 @@ export const loadPluginTemplates = async (c: RnvContext) => {
                 // This comes from rnv built-in dependency (installed via yarn might install it 2 level up but scoped to @rnv)
                 flexnPluginsPath = path.resolve(__dirname, '../../../../@flexn/plugins');
                 if (!fsExistsSync(flexnPluginsPath)) {
-                    return Promise.reject(`RNV Cannot find package: ${chalk().white(flexnPluginsPath)}`);
+                    return Promise.reject(`RNV Cannot find package: ${chalk().bold(flexnPluginsPath)}`);
                 }
             }
         }
@@ -620,14 +620,14 @@ const _overridePlugin = (c: RnvContext, pluginsPath: string, dir: string) => {
 
     if (flavourSource && fsExistsSync(flavourSource)) {
         logInfo(
-            `${chalk().white(dest.split('node_modules').pop())} overriden by: ${chalk().white(
+            `${chalk().bold(dest.split('node_modules').pop())} overriden by: ${chalk().bold(
                 flavourSource.split('node_modules').pop()
             )}`
         );
         copyFolderContentsRecursiveSync(flavourSource, dest, false);
     } else if (fsExistsSync(source)) {
         logInfo(
-            `${chalk().white(dest.split('node_modules').pop())} overriden by: ${chalk().white(
+            `${chalk().bold(dest.split('node_modules').pop())} overriden by: ${chalk().bold(
                 source.split('node_modules').pop()
             )}`
         );
@@ -637,7 +637,7 @@ const _overridePlugin = (c: RnvContext, pluginsPath: string, dir: string) => {
         // });
     } else {
         logDebug(
-            `Your plugin configuration has no override path ${chalk().white(source)}. skipping folder override action`
+            `Your plugin configuration has no override path ${chalk().bold(source)}. skipping folder override action`
         );
     }
 
@@ -708,7 +708,7 @@ export const overrideFileContents = (dest: string, override: Record<string, stri
                 } else {
                     foundRegEx = true;
                     logInfo(
-                        `${chalk().white(dest.split('node_modules').pop())} overriden by: ${chalk().white(
+                        `${chalk().bold(dest.split('node_modules').pop())} overriden by: ${chalk().bold(
                             overridePath.split('node_modules').pop()
                         )}`
                     );
@@ -717,7 +717,7 @@ export const overrideFileContents = (dest: string, override: Record<string, stri
                 foundRegEx = true;
                 fileToFix = fileToFix.replace(regEx, override[fk]);
                 logSuccess(
-                    `${chalk().white(dest.split('node_modules').pop())} requires override by: ${chalk().white(
+                    `${chalk().bold(dest.split('node_modules').pop())} requires override by: ${chalk().bold(
                         overridePath.split('node_modules').pop()
                     )}. FIXING...DONE`
                 );
@@ -730,7 +730,7 @@ export const overrideFileContents = (dest: string, override: Record<string, stri
                     logWarning(
                         `No Match found in ${chalk().red(
                             dest.split('node_modules').pop()
-                        )} for expression: ${chalk().gray(term)}. source: ${chalk().white(
+                        )} for expression: ${chalk().gray(term)}. source: ${chalk().bold(
                             overridePath.split('node_modules').pop()
                         )}`
                     );
@@ -805,7 +805,7 @@ export const checkForPluginDependencies = async (c: RnvContext) => {
             const answer = await inquirerPrompt({
                 type: 'confirm',
                 message: `Install ${Object.keys(toAdd).join(', ')}?`,
-                warningMessage: `One or more dependencies are not installed: ${chalk().white(
+                warningMessage: `One or more dependencies are not installed: ${chalk().bold(
                     Object.keys(toAdd).join(', ')
                 )}`,
             });
@@ -862,7 +862,7 @@ export const overrideTemplatePlugins = async (c: RnvContext) => {
                 }
             } else {
                 logInfo(
-                    `Plugin overrides disabled for: ${chalk().white(key)} with disablePluginTemplateOverrides. SKIPPING`
+                    `Plugin overrides disabled for: ${chalk().bold(key)} with disablePluginTemplateOverrides. SKIPPING`
                 );
             }
         },

--- a/packages/core/src/projects/dependencyManager.ts
+++ b/packages/core/src/projects/dependencyManager.ts
@@ -154,14 +154,14 @@ export const injectPlatformDependencies = async (c: RnvContext) => {
             const { isMonorepo } = c.buildConfig;
             if (isMonorepo) {
                 logInfo(
-                    `Found extra npm dependencies required by ${chalk().white(
+                    `Found extra npm dependencies required by ${chalk().bold(
                         engine.config.id
                     )} engine. project marked as monorepo. SKIPPING`
                 );
             } else {
                 // do npm i only if something new is added
                 logInfo(
-                    `Found extra npm dependencies required by ${chalk().white(engine.config.id)} engine. ADDING...DONE`
+                    `Found extra npm dependencies required by ${chalk().bold(engine.config.id)} engine. ADDING...DONE`
                 );
                 await installPackageDependencies(c);
                 await overrideTemplatePlugins(c);

--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -230,7 +230,7 @@ export const configureFonts = async (c: RnvContext) => {
                               file: require('${fontSource}'),
                           },`;
                         } else {
-                            logWarning(`Font ${chalk().white(fontSource)} doesn't exist! Skipping.`);
+                            logWarning(`Font ${chalk().bold(fontSource)} doesn't exist! Skipping.`);
                         }
                     }
                 }
@@ -291,9 +291,9 @@ export const copyRuntimeAssets = async (c: RnvContext) => {
     if (!c.buildConfig?.common) {
         logDebug('BUILD_CONFIG', c.buildConfig);
         logWarning(
-            `Your ${chalk().white(
+            `Your ${chalk().bold(
                 c.paths.appConfig.config
-            )} is misconfigured. (Maybe you have older version?). Missing ${chalk().white(
+            )} is misconfigured. (Maybe you have older version?). Missing ${chalk().bold(
                 '{ common: {} }'
             )} object at root`
         );
@@ -392,9 +392,9 @@ const _resolvePackage = (c: RnvContext, v: string) => {
 //     if (assetsToCopy.length > 0) {
 //         if (!fsExistsSync(assetsDir)) {
 //             logInfo(
-//                 `Required assets: ${chalk().white(
+//                 `Required assets: ${chalk().bold(
 //                     JSON.stringify(assetsToCopy.map((v) => v.value))
-//                 )} will be copied to ${chalk().white('appConfigs/assets')} folder`
+//                 )} will be copied to ${chalk().bold('appConfigs/assets')} folder`
 //             );
 //             return true;
 //         }
@@ -467,7 +467,7 @@ export const copyAssetsFolder = async (
     // FOLDER MERGERS FROM EXTERNAL SOURCES
     if (validAssetSources.length > 0) {
         logInfo(
-            `Found custom assetSources at ${chalk().white(
+            `Found custom assetSources at ${chalk().bold(
                 validAssetSources.join('/n')
             )}. Will be used to generate assets.`
         );
@@ -523,7 +523,7 @@ export const copyAssetsFolder = async (
 // if (c.program.ci !== true && c.program.yes !== true && !forceTrue) {
 //     const { confirm } = await inquirerPrompt({
 //         type: 'confirm',
-//         message: `It seems you don't have assets configured in ${chalk().white(
+//         message: `It seems you don't have assets configured in ${chalk().bold(
 //             sourcePath
 //         )} do you want generate default ones?`,
 //     });
@@ -611,7 +611,7 @@ export const versionCheck = async (c: RnvContext) => {
     );
     if (c.runtime.rnvVersionRunner && c.runtime.rnvVersionProject) {
         if (c.runtime.rnvVersionRunner !== c.runtime.rnvVersionProject && !c.program.skipRnvCheck) {
-            const recCmd = chalk().white(`$ npx ${getCurrentCommand(true)}`);
+            const recCmd = chalk().bold(`$ npx ${getCurrentCommand(true)}`);
             const actionNoUpdate = 'Continue and skip updating package.json';
             const actionWithUpdate = 'Continue and update package.json';
             const actionUpgrade = `Upgrade project to ${c.runtime.rnvVersionRunner}`;

--- a/packages/core/src/system/exec.ts
+++ b/packages/core/src/system/exec.ts
@@ -91,7 +91,7 @@ const _execute = (c: RnvContext, command: string | Array<string>, opts: ExecOpti
         mono: c.program?.mono || c.program?.json,
     };
 
-    const blue2 = chalk().rgb(50, 50, 255);
+    const blue2 = chalk().rgb(50, 50, 255).bold;
 
     const mergedOpts = { ...defaultOpts, ...opts };
 
@@ -126,7 +126,7 @@ const _execute = (c: RnvContext, command: string | Array<string>, opts: ExecOpti
         if (opts.cwd) {
             logMsg = `cd ${opts.cwd} ${chalk().cyan('&&')} ${logMsg}`;
         }
-        logRaw(`${blue2('[ exec ]')} ${blue2('<[')} ${logMsg} ${blue2(']>')}`);
+        logRaw(`${blue2('exec:')} ${blue2('○')} ${logMsg} ${blue2('○')}`);
     }
 
     logDebug(`_execute: ${logMessage}`);

--- a/packages/core/src/system/exec.ts
+++ b/packages/core/src/system/exec.ts
@@ -273,9 +273,9 @@ const execCLI = (c: RnvContext, cli: string, command: string, opts: ExecOptions 
             c.buildConfig?.sdks
         );
         return Promise.reject(
-            `Location of your cli ${chalk().white(p)} does not exists. check your ${chalk().white(
+            `Location of your cli ${chalk().bold(p)} does not exists. check your ${chalk().bold(
                 c.paths.workspace.config
-            )} file if your ${chalk().white('sdks')} paths are correct`
+            )} file if your ${chalk().bold('sdks')} paths are correct`
         );
     }
 

--- a/packages/core/src/system/fs.ts
+++ b/packages/core/src/system/fs.ts
@@ -519,7 +519,7 @@ export const readObjectSync = <T = object>(filePath?: string, sanitize?: boolean
             }
         }
     } catch (e) {
-        logError(`readObjectSync: Parsing of ${chalk().white(filePath)} failed with ${e}`);
+        logError(`readObjectSync: Parsing of ${chalk().bold(filePath)} failed with ${e}`);
         return null;
     }
     return obj as T;
@@ -540,7 +540,7 @@ export const updateObjectSync = (filePath: string, updateObj: object) => {
 export const getRealPath = (c: RnvContext, p: string | undefined, key = 'undefined', original?: string) => {
     if (!p) {
         if (original) {
-            logDebug(`Path ${chalk().white(key)} is not defined. using default: ${chalk().white(original)}`);
+            logDebug(`Path ${chalk().bold(key)} is not defined. using default: ${chalk().bold(original)}`);
         }
         return original;
     }
@@ -572,7 +572,7 @@ const _refToValue = (c: RnvContext, ref: string, key: string) => {
             const output = lGet(obj, valPath);
             return output;
         } else {
-            logWarning(`_refToValue: ${chalk().white(realPath)} does not exist!`);
+            logWarning(`_refToValue: ${chalk().bold(realPath)} does not exist!`);
         }
     }
     return ref;

--- a/packages/core/src/tasks/constants.ts
+++ b/packages/core/src/tasks/constants.ts
@@ -13,7 +13,7 @@ export const DEFAULT_TASK_DESCRIPTIONS: Record<string, string> = {
 export const RnvTaskOptions: Record<string, RnvTaskOption> = {
     info: {
         shortcut: 'i',
-        value: 'value',
+        isValueType: true,
         description: 'Show full debug Info',
     },
     printExec: {
@@ -25,66 +25,66 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
     },
     platform: {
         shortcut: 'p',
-        value: 'value',
+        isValueType: true,
         description: 'select specific Platform',
     },
     appConfigID: {
         shortcut: 'c',
-        value: 'value',
+        isValueType: true,
         description: 'select specific app Config id',
     },
     target: {
         shortcut: 't',
-        value: 'value',
+        isValueType: true,
         description: 'select specific Target device/simulator',
     },
     projectName: {
-        value: 'value',
+        isValueType: true,
         description: 'select the name of the new project',
     },
     projectTemplate: {
-        value: 'value',
+        isValueType: true,
         description: 'select the template of new project',
     },
     templateVersion: {
-        value: 'value',
+        isValueType: true,
         description: 'select the template version',
     },
     title: {
-        value: 'value',
+        isValueType: true,
         description: 'select the title of the app',
     },
     id: {
-        value: 'value',
+        isValueType: true,
         description: 'select the id of the app',
     },
     appVersion: {
-        value: 'value',
+        isValueType: true,
         description: 'select the version of the app',
     },
     workspace: {
-        value: 'value',
+        isValueType: true,
         description: 'select the workspace for the new project',
     },
     template: {
         shortcut: 'T',
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'select specific template',
     },
     device: {
         shortcut: 'd',
-        value: 'value',
+        isValueType: true,
         description: 'select connected Device',
     },
     scheme: {
         shortcut: 's',
-        value: 'value',
+        isValueType: true,
         description: 'select build Scheme',
     },
     filter: {
         shortcut: 'f',
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Filter value',
     },
@@ -110,13 +110,13 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
     },
     key: {
         shortcut: 'k',
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Pass the key/password',
     },
     blueprint: {
         shortcut: 'b',
-        value: 'value',
+        isValueType: true,
         description: 'Blueprint for targets',
     },
     help: {
@@ -125,24 +125,24 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
     },
     host: {
         shortcut: 'H',
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'custom Host ip',
     },
     exeMethod: {
         shortcut: 'x',
-        value: 'value',
+        isValueType: true,
         description: 'eXecutable method in buildHooks',
     },
     port: {
         shortcut: 'P',
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'custom Port',
     },
     debug: {
         shortcut: 'D',
-        value: 'value',
+        isValueType: true,
         description: 'enable or disable remote debugger.',
         examples: [
             '--debug weinre //run remote debug with weinre as preference',
@@ -157,12 +157,12 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
     },
     engine: {
         shortcut: 'e',
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'engine to be used (next)',
     },
     debugIp: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: '(optional) overwrite the ip to which the remote debugger will connect',
     },
@@ -176,22 +176,22 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
         description: 'Skip sending any integrated notifications',
     },
     keychain: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Name of the keychain',
     },
     provisioningStyle: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Set provisioningStyle (Automatic | Manual)',
     },
     codeSignIdentity: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Set codeSignIdentity (ie iPhone Distribution)',
     },
     provisionProfileSpecifier: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Name of provisionProfile',
     },
@@ -202,7 +202,7 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
         description: 'Force rebuild hooks',
     },
     maxErrorLength: {
-        value: 'number',
+        isValueType: true,
         isRequired: true,
         description: 'Specify how many characters each error should display. Default 200',
     },
@@ -213,17 +213,17 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
         description: 'Enable real-time bundle analyzer',
     },
     xcodebuildArgs: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'pass down custom xcodebuild arguments',
     },
     xcodebuildArchiveArgs: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'pass down custom xcodebuild arguments',
     },
     xcodebuildExportArgs: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'pass down custom xcodebuild arguments',
     },
@@ -234,17 +234,17 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
         description: 'Skips auto update of rnv dependencies if mismatch found',
     },
     configName: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Use custom name for ./renative.json. (applies only at root level)',
     },
     sourceAppConfigID: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'name of source appConfig folder to copy from',
     },
     hostIp: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'Custom IP override',
     },
@@ -256,7 +256,7 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
     },
     gitEnabled: {
         description: 'Enable git in your newly created project',
-        value: 'value',
+        isValueType: true,
     },
     npxMode: {
         description: 'Ensures you can use local npx rnv version after the command is done',
@@ -265,23 +265,23 @@ export const RnvTaskOptions: Record<string, RnvTaskOption> = {
         description: 'Outputs the result as json',
     },
     packageManager: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         options: ['yarn', 'npm'],
         description: 'Set specific package manager to use',
         examples: ['--packageManager yarn', '--packageManager npm'],
     },
     skipTasks: {
-        value: 'value',
+        isValueType: true,
         isRequired: true,
         description: 'List tasks which you want to skip during rnv execution',
         examples: ['--skipTasks "configure,export"', '--skipTasks deploy'],
     },
     answer: {
-        value: 'value',
-        variadic: true,
+        isValueType: true,
+        isVariadic: true,
         description: 'Pass in answers to prompts',
-        examples: ['--answer question=response --answer question2=response2', '--answer question=\'{"some": "json"}\''],
+        examples: ['--answer question=response question2=response2', '--answer question=\'{"some": "json"}\''],
     },
     resetAdb: {
         description: 'Forces to reset android adb',

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -193,9 +193,6 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
         );
 
         const isAutoComplete = !suitableEngines.length && !!c.command && !autocompleteEngines.length;
-        const message = isAutoComplete
-            ? `Autocomplete action for "${c.command}"`
-            : `Pick a subCommand for ${c.command}`;
 
         if (!suitableEngines.length) {
             // Get all supported tasks
@@ -218,7 +215,8 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
             });
             Object.values(CUSTOM_TASKS).forEach((taskInstance) => {
                 const tskArr = taskInstance.task.split(' ');
-                if (task === tskArr[0]) {
+
+                if (task === tskArr[0] && tskArr.length > 1) {
                     const taskKey = isAutoComplete ? taskInstance.task : taskInstance.task.split(' ')[1];
 
                     supportedSubtasksArr.push({
@@ -227,6 +225,7 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
                     });
                 }
             });
+
             const supportedSubtasks: TaskItemMap = {};
             // Normalize task options
             const supportedSubtasksFilter: TaskItemMap = {};
@@ -247,6 +246,10 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
                     taskKey: v.taskKey,
                 };
             });
+
+            const message = isAutoComplete
+                ? `Autocomplete action for "${c.command}"`
+                : `Pick a subCommand for ${c.command}`;
 
             const subTasks = Object.keys(supportedSubtasks);
             if (subTasks.length) {

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -285,7 +285,7 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
                 return findSuitableTask(c);
             }
 
-            logInfo(`could not find suitable task for ${chalk().white(c.command)}. GETTING OPTIONS...`);
+            logInfo(`could not find suitable task for ${chalk().bold(c.command)}. GETTING OPTIONS...`);
             c.command = null;
             c.subCommand = null;
             return findSuitableTask(c);
@@ -305,7 +305,7 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
         }
 
         logInfo(
-            `Current Engine: ${chalk().bold.cyan(c.runtime.engine?.config.id)} path: ${chalk().grey(
+            `Current Engine: ${chalk().bold(c.runtime.engine?.config.id)} path: ${chalk().grey(
                 c.runtime.engine?.rootPath
             )}`
         );
@@ -443,7 +443,7 @@ const ACCEPTED_CONDITIONS = ['platform', 'target', 'appId', 'scheme'] as const;
 type ACKey = (typeof ACCEPTED_CONDITIONS)[number];
 
 const _logSkip = (task: string) => {
-    logInfo(`Original RNV task ${chalk().white(task)} marked to ignore. SKIPPING...`);
+    logInfo(`Original RNV task ${chalk().bold(task)} marked to ignore. SKIPPING...`);
 };
 
 export const shouldSkipTask = (c: RnvContext, taskKey: string, originRnvTaskName?: string) => {

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -305,7 +305,7 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
         }
 
         logInfo(
-            `Current Engine: ${chalk().bold.white(c.runtime.engine?.config.id)} path: ${chalk().grey(
+            `Current Engine: ${chalk().bold.cyan(c.runtime.engine?.config.id)} path: ${chalk().grey(
                 c.runtime.engine?.rootPath
             )}`
         );
@@ -377,9 +377,10 @@ export const executeTask = async (
     originTask?: string,
     isFirstTask?: boolean
 ) => {
-    const pt = parentTask ? `=> [${parentTask}] ` : '';
+    // const pt = parentTask ? `=> [${parentTask}] ` : '';
     c._currentTask = task;
-    logInitTask(`${pt}=> [${chalk().bold.rgb(170, 106, 170)(task)}]`);
+    // logInitTask(`${pt}=> [${chalk().bold.rgb(170, 106, 170)(task)}]`);
+    logInitTask(`${task}`);
 
     if (!executedTasks[task]) executedTasks[task] = 0;
     if (executedTasks[task] > TASK_LIMIT) {
@@ -402,8 +403,8 @@ To avoid that test your task code against parentTask and avoid executing same ta
     executedTasks[task]++;
 
     c._currentTask = parentTask;
-    const prt = parentTask ? `<= [${chalk().rgb(170, 106, 170)(parentTask)}] ` : '';
-    logExitTask(`${prt}<= ${task}`);
+    // const prt = parentTask ? `<= [${chalk().rgb(170, 106, 170)(parentTask)}] ` : '';
+    logExitTask(`${task}`);
 };
 
 /**

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -9,7 +9,7 @@ import {
     registerAllPlatformEngines,
 } from '../engines';
 import type { RnvContext } from '../context/types';
-import type { RnvTask, RnvTaskMap, TaskItemMap, TaskObj, TaskPromptOption } from './types';
+import type { RnvTask, RnvTaskMap, RnvTaskOption, TaskItemMap, TaskObj, TaskPromptOption } from './types';
 import type { RnvEngine } from '../engines/types';
 import { inquirerPrompt, inquirerSeparator, pressAnyKeyToContinue } from '../api';
 import { getApi } from '../api/provider';
@@ -328,22 +328,32 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
     return getEngineTask(task, c.runtime.engine?.tasks);
 };
 
+export const generateStringFromTaskOption = (opt: RnvTaskOption) => {
+    let cmd = '';
+    if (opt.shortcut) {
+        cmd += `-${opt.shortcut}, `;
+    }
+    cmd += `--${opt.key}`;
+    if (opt.isVariadic) {
+        if (opt.isRequired) {
+            cmd += ` <value...>`;
+        } else {
+            cmd += ` [value...]`;
+        }
+    } else if (opt.isValueType) {
+        if (opt.isRequired) {
+            cmd += ` <value>`;
+        } else {
+            cmd += ` [value]`;
+        }
+    }
+    return cmd;
+};
+
 const _populateExtraParameters = (c: RnvContext, task: RnvTask) => {
     if (task.options) {
-        task.options.forEach((param) => {
-            let cmd = '';
-            if (param.shortcut) {
-                cmd += `-${param.shortcut}, `;
-            }
-            cmd += `--${param.key}`;
-            if (param.value) {
-                if (param.isRequired) {
-                    cmd += ` <${param.value}>`;
-                } else {
-                    cmd += ` [${param.value}]`;
-                }
-            }
-            c.program.option?.(cmd, param.description);
+        task.options.forEach((opt) => {
+            c.program.option?.(generateStringFromTaskOption(opt), opt.description);
         });
         c.program.parse?.(process.argv);
     }

--- a/packages/core/src/tasks/types.ts
+++ b/packages/core/src/tasks/types.ts
@@ -32,13 +32,13 @@ export type TaskPromptOption = {
 
 export type RnvTaskOption = {
     shortcut?: string;
-    value?: string;
     key?: string;
     isRequired?: boolean;
+    isValueType?: boolean;
+    isVariadic?: boolean;
     description: string;
     examples?: Array<string>;
     options?: Array<string>;
-    variadic?: boolean;
 };
 
 export type RnvTaskMap = Record<string, RnvTask>;

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -58,7 +58,7 @@ const _applyTemplate = async (c: RnvContext) => {
 
     if (!fsExistsSync(c.paths.template.configTemplate)) {
         logWarning(
-            `Template file ${chalk().white(c.paths.template.configTemplate)} does not exist. check your ${chalk().white(
+            `Template file ${chalk().bold(c.paths.template.configTemplate)} does not exist. check your ${chalk().bold(
                 c.paths.template.dir
             )}. skipping`
         );
@@ -92,7 +92,7 @@ const _configureSrc = (c: RnvContext) =>
         // Check src
         logDebug('configureProject:check src');
         if (!fsExistsSync(c.paths.project.srcDir)) {
-            logInfo(`Your src folder ${chalk().white(c.paths.project.srcDir)} is missing! CREATING...DONE`);
+            logInfo(`Your src folder ${chalk().bold(c.paths.project.srcDir)} is missing! CREATING...DONE`);
             copyFolderContentsRecursiveSync(path.join(c.paths.template.dir, 'src'), c.paths.project.srcDir);
         }
         resolve();
@@ -104,7 +104,7 @@ const _configureAppConfigs = async (c: RnvContext) => {
     //
     if (!fsExistsSync(c.paths.project.appConfigsDir)) {
         logInfo(
-            `Your appConfig folder ${chalk().white(
+            `Your appConfig folder ${chalk().bold(
                 c.paths.project.appConfigsDir
             )} is missing! ReNative will create one from template.`
         );
@@ -156,7 +156,7 @@ const _configureProjectConfig = (c: RnvContext) =>
         logDebug('configureProject:check projectConfigs');
         if (!fsExistsSync(c.paths.project.appConfigBase.dir)) {
             logInfo(
-                `Your projectConfig folder ${chalk().white(
+                `Your projectConfig folder ${chalk().bold(
                     c.paths.project.appConfigBase.dir
                 )} is missing! CREATING...DONE`
             );
@@ -219,12 +219,10 @@ export const configureTemplateFiles = async (c: RnvContext) => {
                 if (!fsExistsSync(destPath) && fsExistsSync(sourcePath)) {
                     try {
                         if (fsLstatSync(sourcePath).isDirectory()) {
-                            logInfo(
-                                `Missing directory ${chalk().white(`${destPath}.js`)}. COPYING from TEMPATE...DONE`
-                            );
+                            logInfo(`Missing directory ${chalk().bold(`${destPath}.js`)}. COPYING from TEMPATE...DONE`);
                             copyFolderContentsRecursiveSync(sourcePath, destPath);
                         } else {
-                            logInfo(`Missing file ${chalk().white(`${destPath}.js`)}. COPYING from TEMPATE...DONE`);
+                            logInfo(`Missing file ${chalk().bold(`${destPath}.js`)}. COPYING from TEMPATE...DONE`);
                             copyFileSync(sourcePath, destPath);
                         }
                     } catch (e) {
@@ -249,18 +247,18 @@ export const configureEntryPoint = async (c: RnvContext, platform: RnvPlatform) 
         if (!fsExistsSync(dest)) {
             if (!entryFile) {
                 logWarning(
-                    `Missing entryFile key for ${chalk().white(c.platform)} platform in your ${chalk().white(
+                    `Missing entryFile key for ${chalk().bold(c.platform)} platform in your ${chalk().bold(
                         c.paths.appConfig.config
                     )}.`
                 );
             } else if (!fsExistsSync(source)) {
                 logWarning(
-                    `Missing entry file ${chalk().white(
+                    `Missing entry file ${chalk().bold(
                         `${entryFile}.js`
                     )}. Not available in your current template. You need to create one manually`
                 );
             } else {
-                logInfo(`Missing entry file ${chalk().white(`${entryFile}.js`)}. COPYING from TEMPATE...DONE`);
+                logInfo(`Missing entry file ${chalk().bold(`${entryFile}.js`)}. COPYING from TEMPATE...DONE`);
                 copyFileSync(source, dest);
             }
         }

--- a/packages/engine-core/src/tasks/app/taskAppConfigure.ts
+++ b/packages/engine-core/src/tasks/app/taskAppConfigure.ts
@@ -115,7 +115,7 @@ const _findAndSwitchAppConfigDir = async (c: RnvContext) => {
     if (appConfigsDirNames.length) {
         if (appConfigsDirNames.length === 1) {
             // we have only one, skip the question
-            logInfo(`Found only one app config available. Will use ${chalk().white(appConfigsDirNames[0])}`);
+            logInfo(`Found only one app config available. Will use ${chalk().bold(appConfigsDirNames[0])}`);
             _setAppId(c, appConfigsDirNames[0]);
             return true;
         }
@@ -181,7 +181,7 @@ const taskAppConfigure = async (c: RnvContext) => {
     } else if (c.program.appConfigID) {
         const aid = await matchAppConfigID(c, c.program.appConfigID);
         if (!aid) {
-            logWarning(`Cannot find app config ${chalk().white(c.program.appConfigID)}`);
+            logWarning(`Cannot find app config ${chalk().bold(c.program.appConfigID)}`);
             const hasAppConfig = await _findAndSwitchAppConfigDir(c);
             if (!hasAppConfig) {
                 // await executeTask(c, RnvTaskName.appCreate, RnvTaskName.appConfigure);

--- a/packages/engine-core/src/tasks/crypto/common.ts
+++ b/packages/engine-core/src/tasks/crypto/common.ts
@@ -16,9 +16,9 @@ import path from 'path';
 
 export const getEnvExportCmd = (envVar: string, key: string) => {
     if (isSystemWin) {
-        return `${chalk().white(`setx ${envVar} "${key}"`)}`;
+        return `${chalk().bold(`setx ${envVar} "${key}"`)}`;
     }
-    return `${chalk().white(`export ${envVar}="${key}"`)}`;
+    return `${chalk().bold(`export ${envVar}="${key}"`)}`;
 };
 
 export const getEnvVar = (c: RnvContext) => {

--- a/packages/engine-core/src/tasks/crypto/taskCryptoDecrypt.ts
+++ b/packages/engine-core/src/tasks/crypto/taskCryptoDecrypt.ts
@@ -78,7 +78,7 @@ const taskCryptoDecrypt: RnvTaskFn = async (c, parentTask, originTask) => {
                 name: 'option',
                 type: 'list',
                 choices: options,
-                message: `How to decrypt to ${chalk().white(destFolder)} ?`,
+                message: `How to decrypt to ${chalk().bold(destFolder)} ?`,
             });
             if (option === options[0]) {
                 shouldCleanFolder = true;
@@ -92,7 +92,7 @@ const taskCryptoDecrypt: RnvTaskFn = async (c, parentTask, originTask) => {
         if (fsExistsSync(destTemp)) {
             const { confirm } = await inquirerPrompt({
                 type: 'confirm',
-                message: `Found existing decrypted file at ${chalk().white(
+                message: `Found existing decrypted file at ${chalk().bold(
                     destTemp
                 )}. want to use it and skip decrypt ?`,
             });
@@ -104,7 +104,7 @@ const taskCryptoDecrypt: RnvTaskFn = async (c, parentTask, originTask) => {
 
         const key = c.program.key || c.process.env[envVar];
         if (!key) {
-            return Promise.reject(`encrypt: You must pass ${chalk().white('--key')} or have env var defined:
+            return Promise.reject(`encrypt: You must pass ${chalk().bold('--key')} or have env var defined:
 
 ${getEnvExportCmd(envVar, 'REPLACE_WITH_ENV_VARIABLE')}
 
@@ -112,7 +112,7 @@ Make sure you take into account special characters that might need to be escaped
 `);
         }
         if (!fsExistsSync(source)) {
-            return Promise.reject(`Can't decrypt. ${chalk().white(source)} is missing!`);
+            return Promise.reject(`Can't decrypt. ${chalk().bold(source)} is missing!`);
         }
 
         let data;
@@ -130,14 +130,14 @@ ${e}
       ${chalk().green('SUGGESTION:')}
 
       ${chalk().yellow('STEP 1:')}
-      run: ${chalk().white('rnv crypto encrypt')} locally at least once and commit the result back to your repository
+      run: ${chalk().bold('rnv crypto encrypt')} locally at least once and commit the result back to your repository
 
       ${chalk().yellow('STEP 2:')}
-      you should be able to use: ${chalk().white('rnv crypto decrypt')} properly now
+      you should be able to use: ${chalk().bold('rnv crypto decrypt')} properly now
 
       ${chalk().yellow('IF ALL HOPE IS LOST:')}
       Raise new issue and copy this SUMMARY box output at:
-      ${chalk().white('https://github.com/flexn-io/renative/issues')}
+      ${chalk().bold('https://github.com/flexn-io/renative/issues')}
       and we will try to help!
 
       `;
@@ -154,14 +154,14 @@ ${chalk().green('SUGGESTION:')}
 ${chalk().yellow('STEP 1:')}
 check if your ENV VAR is correct: ${getEnvExportCmd(envVar, '***********')}
 Make sure you take into account special characters that might need to be escaped
-or if someone did not encrypt ${chalk().white(source)} with a different key
+or if someone did not encrypt ${chalk().bold(source)} with a different key
 
 ${chalk().yellow('STEP 2:')}
 run crypto decrypt again
 
 ${chalk().yellow('IF ALL HOPE IS LOST:')}
 Raise new issue and copy this SUMMARY box output at:
-${chalk().white('https://github.com/flexn-io/renative/issues')}
+${chalk().bold('https://github.com/flexn-io/renative/issues')}
 and we will try to help!
 
 `);
@@ -183,7 +183,7 @@ and we will try to help!
         //                 { privateParams: [key] }
         //             );
         //         } catch (e) {
-        //             const cmd1 = chalk().white(
+        //             const cmd1 = chalk().bold(
         //                 `openssl enc -aes-256-cbc -md md5 -d -in ${source} -out ${destTemp} -k $${envVar}`
         //             );
         //             return Promise.reject(`${e}
@@ -194,14 +194,14 @@ and we will try to help!
         // ${cmd1}
 
         // ${chalk().yellow('STEP 2:')}
-        // ${chalk().white(
+        // ${chalk().bold(
         //         'run your previous command again and choose to skip openssl once asked'
         //     )}`);
         //         }
 
         await _unzipAndCopy(c, shouldCleanFolder, destTemp, wsPath, ts, destFolder);
     } else {
-        logWarning(`You don't have {{ crypto.path }} specificed in ${chalk().white(c.paths.appConfigBase)}`);
+        logWarning(`You don't have {{ crypto.path }} specificed in ${chalk().bold(c.paths.appConfigBase)}`);
         return true;
     }
 };

--- a/packages/engine-core/src/tasks/crypto/taskCryptoEncrypt.ts
+++ b/packages/engine-core/src/tasks/crypto/taskCryptoEncrypt.ts
@@ -122,7 +122,7 @@ const _checkAndConfigureCrypto = async (c: RnvContext) => {
 
     if (!fsExistsSync(sourceFolder)) {
         logInfo(
-            `It seems you are running encrypt for the first time. Directory ${chalk().white(
+            `It seems you are running encrypt for the first time. Directory ${chalk().bold(
                 sourceFolder
             )} does not exist yet.
 RNV will create it for you, make sure you add whatever you want encrypted in it and then run the command again`
@@ -150,7 +150,7 @@ RNV will create it for you, make sure you add whatever you want encrypted in it 
             key = generateRandomKey(20);
             keyGenerated = true;
         } else {
-            return Promise.reject(`encrypt: You must pass ${chalk().white('--key')} or have env var defined:
+            return Promise.reject(`encrypt: You must pass ${chalk().bold('--key')} or have env var defined:
 
 ${getEnvExportCmd(envVar, 'REPLACE_WITH_ENV_VARIABLE')}
 
@@ -229,7 +229,7 @@ const taskCryptoEncrypt: RnvTaskFn = async (c, _parentTask, originTask) => {
         fsWriteFileSync(`${tsWorkspacePath}`, `${timestamp}`);
         logSuccess(`Files succesfully encrypted into ${dest}`);
     } else {
-        logWarning(`You don't have {{ crypto.path }} specificed in ${chalk().white(c.paths.appConfigBase)}`);
+        logWarning(`You don't have {{ crypto.path }} specificed in ${chalk().bold(c.paths.appConfigBase)}`);
     }
 };
 

--- a/packages/engine-core/src/tasks/global/__tests__/taskClean.test.ts
+++ b/packages/engine-core/src/tasks/global/__tests__/taskClean.test.ts
@@ -1,8 +1,8 @@
 import {
-    createRnvApi,
     createRnvContext,
     executeAsync,
     fsExistsSync,
+    fsReaddirSync,
     getContext,
     inquirerPrompt,
     removeDirs,
@@ -14,7 +14,6 @@ jest.mock('path');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {
@@ -28,6 +27,7 @@ test('Execute task.rnv.clean', async () => {
         Promise.resolve({ confirm: true, confirmBuilds: true, confirmLocals: true, confirmCache: true })
     );
     jest.mocked(fsExistsSync).mockReturnValue(true);
+    jest.mocked(fsReaddirSync).mockReturnValue([]);
     ctx.program.ci = false;
     //WHEN
     await expect(taskClean.fn?.(ctx)).resolves.toEqual(true);

--- a/packages/engine-core/src/tasks/global/__tests__/taskKill.test.ts
+++ b/packages/engine-core/src/tasks/global/__tests__/taskKill.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, executeTask, getContext } from '@rnv/core';
+import { createRnvContext, executeTask, getContext } from '@rnv/core';
 import taskKill from '../taskKill';
 
 jest.mock('@rnv/core');
@@ -7,7 +7,6 @@ jest.mock('kill-port');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/engine-core/src/tasks/global/__tests__/taskNew.test.ts
+++ b/packages/engine-core/src/tasks/global/__tests__/taskNew.test.ts
@@ -1,5 +1,4 @@
 import {
-    createRnvApi,
     createRnvContext,
     fsExistsSync,
     getContext,
@@ -19,7 +18,6 @@ jest.mock('semver');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/engine-core/src/tasks/global/taskHelp.ts
+++ b/packages/engine-core/src/tasks/global/taskHelp.ts
@@ -7,6 +7,7 @@ import {
     RnvTaskFn,
     RnvTask,
     RnvTaskName,
+    generateStringFromTaskOption,
 } from '@rnv/core';
 
 const taskHelp: RnvTaskFn = async (c) => {
@@ -16,19 +17,7 @@ const taskHelp: RnvTaskFn = async (c) => {
     let optsString = '';
 
     RnvTaskOptionPresets.withAll().forEach((param) => {
-        let cmd = '';
-        if (param.shortcut) {
-            cmd += `-${param.shortcut}, `;
-        }
-        cmd += `--${param.key}`;
-        if (param.value) {
-            if (param.isRequired) {
-                cmd += ` <${param.value}>`;
-            } else {
-                cmd += ` [${param.value}]`;
-            }
-        }
-        optsString += chalk().grey(`${cmd}, ${param.description}\n`);
+        optsString += chalk().grey(`${generateStringFromTaskOption(param)}, ${param.description}\n`);
     });
 
     // TASKS

--- a/packages/engine-core/src/tasks/global/taskHelp.ts
+++ b/packages/engine-core/src/tasks/global/taskHelp.ts
@@ -43,11 +43,11 @@ const taskHelp: RnvTaskFn = async (c) => {
     const cmdsString = commands.join(', ');
 
     logToSummary(`
-${chalk().bold.white('COMMANDS:')}
+${chalk().bold('COMMANDS:')}
 
 ${cmdsString}
 
-${chalk().bold.white('OPTIONS:')}
+${chalk().bold('OPTIONS:')}
 
 ${optsString}
 `);

--- a/packages/engine-core/src/tasks/global/taskKill.ts
+++ b/packages/engine-core/src/tasks/global/taskKill.ts
@@ -51,7 +51,7 @@ const taskKill: RnvTaskFn = async (c, _parentTask, originTask) => {
             type: 'confirm',
             message: 'Processes attached to the ports will be killed. Continue?',
             warningMessage: `Found active ports:
-${usedPorts.map((v) => chalk().white(`> ${v.port} (${v.platform})`)).join('\n')}`,
+${usedPorts.map((v) => chalk().bold(`> ${v.port} (${v.platform})`)).join('\n')}`,
         });
         if (confirm) {
             const killPromise = [];

--- a/packages/engine-core/src/tasks/global/taskNew.ts
+++ b/packages/engine-core/src/tasks/global/taskNew.ts
@@ -520,7 +520,7 @@ const taskNew = async (c: RnvContext) => {
         const { confirmAddTemplate } = await inquirerPrompt({
             name: 'confirmAddTemplate',
             type: 'confirm',
-            message: `Would you like to add ${chalk().white(selectedInputTemplate)} to your ${
+            message: `Would you like to add ${chalk().bold(selectedInputTemplate)} to your ${
                 c.runtime.selectedWorkspace
             } workspace template list?`,
         });
@@ -775,7 +775,7 @@ const taskNew = async (c: RnvContext) => {
     }
 
     logSuccess(
-        `Your project is ready! navigate to project ${chalk().white(`cd ${data.projectName}`)} and run ${chalk().white(
+        `Your project is ready! navigate to project ${chalk().bold(`cd ${data.projectName}`)} and run ${chalk().bold(
             'npx rnv run'
         )} to see magic happen!`
     );

--- a/packages/engine-core/src/tasks/platform/__tests__/taskPlatformConfigure.test.ts
+++ b/packages/engine-core/src/tasks/platform/__tests__/taskPlatformConfigure.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, executeTask, getContext } from '@rnv/core';
+import { createRnvContext, executeTask, getContext } from '@rnv/core';
 import taskPlatformConfigure from '../taskPlatformConfigure';
 
 jest.mock('../../../common');
@@ -7,7 +7,6 @@ jest.mock('@rnv/core');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/engine-core/src/tasks/platform/__tests__/taskPlatformList.test.ts
+++ b/packages/engine-core/src/tasks/platform/__tests__/taskPlatformList.test.ts
@@ -1,11 +1,10 @@
-import { createRnvApi, createRnvContext, executeTask, getContext } from '@rnv/core';
+import { createRnvContext, executeTask, generatePlatformChoices, getContext } from '@rnv/core';
 import taskPlatformList from '../taskPlatformList';
 
 jest.mock('@rnv/core');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {
@@ -15,6 +14,7 @@ afterEach(() => {
 test('Execute task.rnv.platform.list', async () => {
     //GIVEN
     const ctx = getContext();
+    jest.mocked(generatePlatformChoices).mockReturnValue([]);
     //WHEN
     await expect(taskPlatformList.fn?.(ctx)).resolves.toEqual(true);
     //THEN

--- a/packages/engine-core/src/tasks/platform/taskPlatformConfigure.ts
+++ b/packages/engine-core/src/tasks/platform/taskPlatformConfigure.ts
@@ -41,7 +41,7 @@ const taskPlatformConfigure: RnvTaskFn = async (c, parentTask, originTask) => {
 
     if ((c.program.reset || c.program.resetHard) && !c.runtime.disableReset) {
         logInfo(
-            `You passed ${chalk().white(c.program.reset ? '-r' : '-R')} argument. "${chalk().white(
+            `You passed ${chalk().bold(c.program.reset ? '-r' : '-R')} argument. "${chalk().bold(
                 getAppFolder(c)
             )}" CLEANING...DONE`
         );

--- a/packages/engine-core/src/tasks/platform/taskPlatformConnect.ts
+++ b/packages/engine-core/src/tasks/platform/taskPlatformConnect.ts
@@ -81,7 +81,7 @@ const taskPlatformConnect: RnvTaskFn = async (c, _parentTask, originTask) => {
     }
 
     logSuccess(
-        `${chalk().white(
+        `${chalk().bold(
             selectedPlatforms.join(',')
         )} now using ReNative platformTemplates located associated platform engines.`
     );

--- a/packages/engine-core/src/tasks/platform/taskPlatformEject.ts
+++ b/packages/engine-core/src/tasks/platform/taskPlatformEject.ts
@@ -31,7 +31,7 @@ const taskPlatformEject: RnvTaskFn = async (c, _parentTask, originTask) => {
     if (c.platform) {
         selectedPlatforms = [c.platform];
     } else {
-        logInfo(`Preparing to eject engine platforms to local ${chalk().white('./platformTemplates')}`);
+        logInfo(`Preparing to eject engine platforms to local ${chalk().bold('./platformTemplates')}`);
         const { ejectedPlatforms } = await inquirerPrompt({
             name: 'ejectedPlatforms',
             message: 'Select platforms you would like to eject (use SPACE key)',
@@ -60,13 +60,13 @@ const taskPlatformEject: RnvTaskFn = async (c, _parentTask, originTask) => {
         });
 
         logSuccess(
-            `${chalk().white(selectedPlatforms.join(','))} platform templates are located in ${chalk().white(
+            `${chalk().bold(selectedPlatforms.join(','))} platform templates are located in ${chalk().bold(
                 c.files.project.config?.paths?.platformTemplatesDirs?.[selectedPlatforms[0]]
             )} now. You can edit them directly!`
         );
     } else {
         logError(`You haven't selected any platform to eject.
-TIP: You can select options with ${chalk().white('SPACE')} key before pressing ENTER!`);
+TIP: You can select options with ${chalk().bold('SPACE')} key before pressing ENTER!`);
     }
 };
 

--- a/packages/engine-core/src/tasks/platform/taskPlatformList.ts
+++ b/packages/engine-core/src/tasks/platform/taskPlatformList.ts
@@ -15,7 +15,7 @@ const taskPlatformList: RnvTaskFn = async (c, _parentTask, originTask) => {
 
     await executeTask(c, RnvTaskName.projectConfigure, RnvTaskName.platformList, originTask);
 
-    const opts = generatePlatformChoices(c).map((v, i) => ` [${chalk().white(i + 1)}]> ${v.name}`);
+    const opts = generatePlatformChoices(c).map((v, i) => ` [${chalk().bold(i + 1)}]> ${v.name}`);
     logToSummary(`Platforms:\n\n${opts.join('\n')}`);
     return true;
 };

--- a/packages/engine-core/src/tasks/plugin/taskPluginAdd.ts
+++ b/packages/engine-core/src/tasks/plugin/taskPluginAdd.ts
@@ -40,10 +40,10 @@ const taskPluginAdd: RnvTaskFn = async (c, _parentTask, originTask) => {
         });
 
         selectedPlugins[plugin] = o.allPlugins[plugin];
-        installMessage.push(`${chalk().white(plugin)} v(${chalk().green(o.allPlugins[plugin].version)})`);
+        installMessage.push(`${chalk().bold(plugin)} v(${chalk().green(o.allPlugins[plugin].version)})`);
     } else {
         selectedPlugins[selPluginKey] = selPlugin;
-        installMessage.push(`${chalk().white(selPluginKey)} v(${chalk().green(selPlugin.version)})`);
+        installMessage.push(`${chalk().bold(selPluginKey)} v(${chalk().green(selPlugin.version)})`);
     }
 
     const questionPlugins: Record<string, PluginListResponseItem> = {};

--- a/packages/engine-core/src/tasks/project/taskProjectConfigure.ts
+++ b/packages/engine-core/src/tasks/project/taskProjectConfigure.ts
@@ -37,9 +37,9 @@ import { checkCrypto } from '../crypto/common';
 const checkIsRenativeProject = async (c: RnvContext) => {
     if (!c.paths.project.configExists) {
         return Promise.reject(
-            `This directory is not ReNative project. Project config ${chalk().white(
+            `This directory is not ReNative project. Project config ${chalk().bold(
                 c.paths.project.config
-            )} is missing!. You can create new project with ${chalk().white('rnv new')}`
+            )} is missing!. You can create new project with ${chalk().bold('rnv new')}`
         );
     }
     return true;
@@ -105,14 +105,14 @@ const taskProjectConfigure: RnvTaskFn = async (c, parentTask, originTask) => {
         if (!c.runtime.disableReset) {
             if (c.program.resetHard) {
                 logInfo(
-                    `You passed ${chalk().white('-R, --resetHard')} argument. "${chalk().white(
+                    `You passed ${chalk().bold('-R, --resetHard')} argument. "${chalk().bold(
                         './platformAssets'
                     )}" will be cleaned up first`
                 );
                 await cleanPlaformAssets(c);
             } else if (c.program.resetAssets) {
                 logInfo(
-                    `You passed ${chalk().white('-a, --resetAssets')} argument. "${chalk().white(
+                    `You passed ${chalk().bold('-a, --resetAssets')} argument. "${chalk().bold(
                         './platformAssets'
                     )}" will be cleaned up first`
                 );

--- a/packages/engine-core/src/tasks/workspace/taskWorkspaceConfigure.ts
+++ b/packages/engine-core/src/tasks/workspace/taskWorkspaceConfigure.ts
@@ -51,13 +51,13 @@ const taskWorkspaceConfigure: RnvTaskFn = async (c) => {
         if (c.files.workspace.config?.appConfigsPath) {
             if (!fsExistsSync(c.files.workspace.config.appConfigsPath)) {
                 logWarning(
-                    `Your custom global appConfig is pointing to ${chalk().white(
+                    `Your custom global appConfig is pointing to ${chalk().bold(
                         c.files.workspace.config.appConfigsPath
                     )} which doesn't exist! Make sure you create one in that location`
                 );
             } else {
                 logInfo(
-                    `Found custom appConfing location pointing to ${chalk().white(
+                    `Found custom appConfing location pointing to ${chalk().bold(
                         c.files.workspace.config.appConfigsPath
                     )}. ReNativewill now swith to that location!`
                 );
@@ -68,7 +68,7 @@ const taskWorkspaceConfigure: RnvTaskFn = async (c) => {
         // Check config sanity
         if (c.files.workspace.config?.defaultTargets === undefined) {
             logWarning(
-                `You're missing defaultTargets in your config ${chalk().white(
+                `You're missing defaultTargets in your config ${chalk().bold(
                     c.paths.workspace.config
                 )}. Let's add them!`
             );

--- a/packages/engine-rn-electron/src/sdk.ts
+++ b/packages/engine-rn-electron/src/sdk.ts
@@ -90,7 +90,7 @@ const configureProject = (c: RnvContext, exitOnFail?: boolean) =>
 
         if (!fsExistsSync(packagePath)) {
             if (exitOnFail) {
-                logWarning(`Your ${chalk().white(platform)} platformBuild is misconfigured!. let's repair it.`);
+                logWarning(`Your ${chalk().bold(platform)} platformBuild is misconfigured!. let's repair it.`);
                 createPlatformBuild(c, platform)
                     .then(() => configureElectronProject(c, true))
                     .then(() => resolve())
@@ -329,7 +329,7 @@ export const runElectron = async (c: RnvContext) => {
         const isPortActive = await checkPortInUse(c, platform, port);
         if (!isPortActive) {
             logInfo(
-                `Your ${chalk().white(platform)} devServer at port ${chalk().white(
+                `Your ${chalk().bold(platform)} devServer at port ${chalk().bold(
                     port
                 )} is not running. Starting it up for you...`
             );
@@ -391,7 +391,7 @@ const _generateICNS = (c: RnvContext) =>
         // It's ok if icns are not generated as png is also valid https://www.electron.build/icons.html#macos
         if (!source) {
             logWarning(
-                `You are missing AppIcon.iconset in ${chalk().white(
+                `You are missing AppIcon.iconset in ${chalk().bold(
                     c.paths.appConfig.dir
                 )}. icon.icns will not be generated!`
             );
@@ -400,7 +400,7 @@ const _generateICNS = (c: RnvContext) =>
         }
 
         if (!fsExistsSync(source)) {
-            logWarning(`Your app config is missing ${chalk().white(source)}. icon.icns will not be generated!`);
+            logWarning(`Your app config is missing ${chalk().bold(source)}. icon.icns will not be generated!`);
             resolve();
             return;
         }

--- a/packages/engine-rn-next/src/env.ts
+++ b/packages/engine-rn-next/src/env.ts
@@ -58,7 +58,7 @@ const _checkPagesDir = () => {
         const pagesDirPath = path.join(c.paths.project.dir, pagesDir);
         if (!fsExistsSync(pagesDirPath)) {
             logWarning(
-                `You configured custom ${c.platform}pagesDir: ${chalk().white(
+                `You configured custom ${c.platform}pagesDir: ${chalk().bold(
                     pagesDir
                 )} in your renative.json but it is missing at ${chalk().red(pagesDirPath)}`
             );
@@ -70,7 +70,7 @@ const _checkPagesDir = () => {
 
     const fallbackPagesDirPath = path.join(c.paths.project.dir, fallbackPagesDir);
     if (!fsExistsSync(fallbackPagesDirPath)) {
-        logWarning(`Folder ${chalk().white(
+        logWarning(`Folder ${chalk().bold(
             fallbackPagesDir
         )} is missing. make sure your entry code is located there in order for next to work correctly!
 Alternatively you can configure custom entry folder via ${c.platform}.pagesDir in renative.json`);

--- a/packages/engine-rn-next/src/sdk.ts
+++ b/packages/engine-rn-next/src/sdk.ts
@@ -56,7 +56,7 @@ export const runWebNext = async (c: RnvContext) => {
 
     if (!isPortActive) {
         logInfo(
-            `Your ${chalk().white(platform)} devServerHost ${chalk().white(devServerHost)} at port ${chalk().white(
+            `Your ${chalk().bold(platform)} devServerHost ${chalk().bold(devServerHost)} at port ${chalk().bold(
                 port
             )} is not running. Starting it up for you...`
         );

--- a/packages/engine-rn-tvos/src/tasks/__tests__/run.test.ts
+++ b/packages/engine-rn-tvos/src/tasks/__tests__/run.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, getContext } from '@rnv/core';
+import { createRnvContext, getContext } from '@rnv/core';
 import taskRun from '../taskRun';
 import { getIosDeviceToRunOn, runXcodeProject } from '@rnv/sdk-apple';
 
@@ -9,7 +9,6 @@ jest.mock('@rnv/sdk-react-native');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/engine-rn-tvos/src/tasks/__tests__/start.test.ts
+++ b/packages/engine-rn-tvos/src/tasks/__tests__/start.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, getContext, logError, doResolve, executeTask } from '@rnv/core';
+import { createRnvContext, getContext, logError, doResolve, executeTask } from '@rnv/core';
 import taskStart from '../taskStart';
 import { startReactNative } from '@rnv/sdk-react-native';
 
@@ -7,7 +7,6 @@ jest.mock('@rnv/sdk-react-native');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/engine-rn-web/src/tasks/__tests__/run.test.ts
+++ b/packages/engine-rn-web/src/tasks/__tests__/run.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, getAppFolder, getContext, getPlatformProjectDir } from '@rnv/core';
+import { createRnvContext, getAppFolder, getContext, getPlatformProjectDir } from '@rnv/core';
 import taskRun from '../taskRun';
 import { runWebpackServer } from '@rnv/sdk-webpack';
 import { runTizen } from '@rnv/sdk-tizen';
@@ -14,7 +14,6 @@ jest.mock('@rnv/sdk-utils');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/engine-rn/src/tasks/__tests__/taskRun.test.ts
+++ b/packages/engine-rn/src/tasks/__tests__/taskRun.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, getContext } from '@rnv/core';
+import { createRnvContext, getContext } from '@rnv/core';
 import taskRun from '../taskRun';
 import { getIosDeviceToRunOn, runXcodeProject } from '@rnv/sdk-apple';
 
@@ -9,7 +9,6 @@ jest.mock('@rnv/sdk-react-native');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/engine-rn/src/tasks/__tests__/taskStart.test.ts
+++ b/packages/engine-rn/src/tasks/__tests__/taskStart.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, executeTask, getContext } from '@rnv/core';
+import { createRnvContext, executeTask, getContext } from '@rnv/core';
 import taskStart from '../taskStart';
 import { startReactNative } from '@rnv/sdk-react-native';
 
@@ -7,30 +7,30 @@ jest.mock('@rnv/sdk-react-native');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {
     jest.resetAllMocks();
 });
 
-test('Execute task.rnv.start with no parent', async () => {
-    // GIVEN
-    const ctx = getContext();
-    ctx.platform = 'ios';
-    jest.mocked(executeTask).mockResolvedValueOnce(undefined);
-    // WHEN
-    await taskStart.fn?.(ctx, undefined, undefined);
-    // THEN
-    expect(startReactNative).toHaveBeenCalledWith(ctx, { waitForBundler: true });
-});
-
-test('Execute task.rnv.start', async () => {
-    // GIVEN
-    const ctx = getContext();
-    ctx.platform = 'ios';
-    // WHEN
-    await taskStart.fn?.(ctx, 'parent', undefined);
-    // THEN
-    expect(startReactNative).toHaveBeenCalledWith(ctx, { waitForBundler: false });
+describe('taskStart', () => {
+    it('Execute task.rnv.start with no parent', async () => {
+        // GIVEN
+        const ctx = getContext();
+        ctx.platform = 'ios';
+        jest.mocked(executeTask).mockResolvedValueOnce(undefined);
+        // WHEN
+        await taskStart.fn?.(ctx, undefined, undefined);
+        // THEN
+        expect(startReactNative).toHaveBeenCalledWith(ctx, { waitForBundler: true });
+    });
+    it('Execute task.rnv.start', async () => {
+        // GIVEN
+        const ctx = getContext();
+        ctx.platform = 'ios';
+        // WHEN
+        await taskStart.fn?.(ctx, 'parent', undefined);
+        // THEN
+        expect(startReactNative).toHaveBeenCalledWith(ctx, { waitForBundler: false });
+    });
 });

--- a/packages/integration-docker/src/docker.ts
+++ b/packages/integration-docker/src/docker.ts
@@ -98,16 +98,16 @@ class Docker {
         logDefault('docker:Dockerfile:build');
         await executeAsync(`docker save -o ${dockerSaveFile} ${imageName}:${appVersion}`);
         logSuccess(
-            `${imageName}_${appVersion}.tar file has been saved in ${chalk().white(
+            `${imageName}_${appVersion}.tar file has been saved in ${chalk().bold(
                 dockerDestination
-            )}. You can import it on another machine by running ${chalk().white(
+            )}. You can import it on another machine by running ${chalk().bold(
                 `'docker load -i ${imageName}_${appVersion}.tar'`
             )}`
         );
         logSuccess(
-            `You can also test it locally by running the following command: ${chalk().white(
+            `You can also test it locally by running the following command: ${chalk().bold(
                 `'docker run -d --rm -p 8081:80 -p 8443:443 ${imageName}:${appVersion}'`
-            )} and then opening ${chalk().white('http://localhost:8081')}`
+            )} and then opening ${chalk().bold('http://localhost:8081')}`
         );
 
         const deployOptions = getConfigProp(c, platform, 'custom').deploy;

--- a/packages/integration-docker/src/index.ts
+++ b/packages/integration-docker/src/index.ts
@@ -2,12 +2,15 @@ import taskDockerDeploy from './tasks/taskDockerDeploy';
 import taskDockerExport from './tasks/taskDockerExport';
 //@ts-ignore
 import config from '../renative.integration.json';
+import { RnvIntegration } from '@rnv/core';
 
 const TASKS = [taskDockerExport, taskDockerDeploy];
 
 const getTasks = () => TASKS;
 
-export default {
+const Integration: RnvIntegration = {
     getTasks,
     config,
 };
+
+export default Integration;

--- a/packages/integration-starter/package.json
+++ b/packages/integration-starter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@rnv/integration-starter",
-    "version": "1.0.0-rc.11",
+    "version": "1.0.0-rc.12",
     "description": "ReNative Example Integration",
     "keywords": [
         "renative",

--- a/packages/integration-starter/src/index.ts
+++ b/packages/integration-starter/src/index.ts
@@ -1,12 +1,15 @@
 import taskStarterHello from './tasks/taskStarterHello';
 //@ts-ignore
 import config from '../renative.integration.json';
+import { RnvIntegration } from '@rnv/core';
 
 const TASKS = [taskStarterHello];
 
 const getTasks = () => TASKS;
 
-export default {
+const Integration: RnvIntegration = {
     getTasks,
     config,
 };
+
+export default Integration;

--- a/packages/integration-starter/src/index.ts
+++ b/packages/integration-starter/src/index.ts
@@ -1,14 +1,12 @@
 import taskStarterHello from './tasks/taskStarterHello';
+import taskSingleCommand from './tasks/taskSingleCommand';
+
 //@ts-ignore
 import config from '../renative.integration.json';
 import { RnvIntegration } from '@rnv/core';
 
-const TASKS = [taskStarterHello];
-
-const getTasks = () => TASKS;
-
 const Integration: RnvIntegration = {
-    getTasks,
+    getTasks: () => [taskStarterHello, taskSingleCommand],
     config,
 };
 

--- a/packages/integration-starter/src/tasks/taskSingleCommand.ts
+++ b/packages/integration-starter/src/tasks/taskSingleCommand.ts
@@ -9,7 +9,7 @@ const Task: RnvTask = {
     description: 'Prints hello message',
     fn: task,
     task: 'starter-single-command',
-    options: RnvTaskOptionPresets.withBase([{ key: 'my-opt', description: 'Hello', value: 'value' }]),
+    options: RnvTaskOptionPresets.withBase([{ key: 'my-opt', description: 'Hello', isValueType: true }]),
     platforms: [],
 };
 

--- a/packages/integration-starter/src/tasks/taskSingleCommand.ts
+++ b/packages/integration-starter/src/tasks/taskSingleCommand.ts
@@ -1,14 +1,14 @@
 import { RnvContext, RnvTaskOptionPresets, logSuccess, RnvTask, RnvTaskFn } from '@rnv/core';
 
 const task: RnvTaskFn = async (c: RnvContext) => {
-    logSuccess(`Hello from Integration Starter! 
+    logSuccess(`Hello from Integration Starter single command! 
 --my-opt: "${c.program.myOpt}"`);
 };
 
 const Task: RnvTask = {
     description: 'Prints hello message',
     fn: task,
-    task: 'starter hello',
+    task: 'starter-single-command',
     options: RnvTaskOptionPresets.withBase([{ key: 'my-opt', description: 'Hello', value: 'value' }]),
     platforms: [],
 };

--- a/packages/integration-starter/src/tasks/taskStarterHello.ts
+++ b/packages/integration-starter/src/tasks/taskStarterHello.ts
@@ -1,16 +1,15 @@
-import { RnvContext, logTask, RnvTaskOptionPresets, logSuccess, RnvTask } from '@rnv/core';
+import { RnvContext, RnvTaskOptionPresets, logSuccess, RnvTask, RnvTaskFn } from '@rnv/core';
 
-const taskStarterHello = async (_c: RnvContext) => {
-    logTask('taskStarterHello');
-
-    logSuccess('Hello from Integration Starter!');
+const taskStarterHello: RnvTaskFn = async (c: RnvContext) => {
+    logSuccess(`Hello from Integration Starter! 
+--my-opt: "${c.program.myOpt}"`);
 };
 
 const Task: RnvTask = {
     description: 'Prints hello message',
     fn: taskStarterHello,
     task: 'starter hello',
-    options: RnvTaskOptionPresets.withBase(),
+    options: RnvTaskOptionPresets.withBase([{ key: 'my-opt', description: 'Hello', value: 'value' }]),
     platforms: [],
 };
 

--- a/packages/integration-starter/src/tasks/taskStarterHello.ts
+++ b/packages/integration-starter/src/tasks/taskStarterHello.ts
@@ -9,7 +9,7 @@ const Task: RnvTask = {
     description: 'Prints hello message',
     fn: task,
     task: 'starter hello',
-    options: RnvTaskOptionPresets.withBase([{ key: 'my-opt', description: 'Hello', value: 'value' }]),
+    options: RnvTaskOptionPresets.withBase([{ key: 'my-opt', description: 'Hello', isValueType: true }]),
     platforms: [],
 };
 

--- a/packages/sdk-android/src/__tests__/runner.test.ts
+++ b/packages/sdk-android/src/__tests__/runner.test.ts
@@ -1,21 +1,11 @@
+import { getAndroidTargets } from '../deviceManager';
 import { getAndroidDeviceToRunOn } from '../runner';
-import { createRnvApi, createRnvContext, getContext } from '@rnv/core';
+import { createRnvContext, getContext } from '@rnv/core';
 
-jest.mock('../deviceManager', () => {
-    return {
-        mockLaunchAndroidSimulator: jest.fn(),
-        resetAdb: jest.fn(),
-        connectToWifiDevice: jest.fn(),
-        getAndroidTargets: jest.fn(),
-        checkForActiveEmulator: jest.fn(),
-        composeDevicesArray: jest.fn(),
-        askForNewEmulator: jest.fn(),
-    };
-});
+jest.mock('../deviceManager');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {
@@ -30,10 +20,8 @@ describe('getAndroidDeviceToRunOn', () => {
         ctx.program.target = 'existingTarget';
         ctx.runtime.target = 'defaultTarget';
         const mockFoundDevice = { name: 'existingTarget', isActive: true, udid: '' };
-        const { getAndroidTargets } = require('../deviceManager');
-        getAndroidTargets.mockResolvedValueOnce([mockFoundDevice]);
+        jest.mocked(getAndroidTargets).mockResolvedValueOnce([mockFoundDevice]);
         //WHEN
-
         const result = await getAndroidDeviceToRunOn(ctx);
         //THEN
         expect(result).toEqual(mockFoundDevice);

--- a/packages/sdk-android/src/deviceManager.ts
+++ b/packages/sdk-android/src/deviceManager.ts
@@ -170,7 +170,7 @@ const _getDeviceAsString = (device: AndroidDevice, i: number): string => {
     const { name, udid, isDevice, isActive, arch } = device;
     const deviceIcon = getDeviceIcon(device);
 
-    const deviceString = `${chalk().white(name)} | ${deviceIcon} | arch: ${arch} | udid: ${chalk().grey(udid)}${
+    const deviceString = `${chalk().bold(name)} | ${deviceIcon} | arch: ${arch} | udid: ${chalk().grey(udid)}${
         isDevice ? chalk().red(' (device)') : ''
     } ${isActive ? chalk().magenta(' (active)') : ''}`;
 
@@ -181,7 +181,7 @@ const _getDeviceAsObject = (device: AndroidDevice): DeviceInfo => {
     const { name, udid, isDevice, isActive, arch } = device;
     const deviceIcon = getDeviceIcon(device);
 
-    const deviceString = `${chalk().white(name)} | ${deviceIcon} | arch: ${arch} | udid: ${chalk().grey(udid)}${
+    const deviceString = `${chalk().bold(name)} | ${deviceIcon} | arch: ${arch} | udid: ${chalk().grey(udid)}${
         isDevice ? chalk().red(' (device)') : ''
     } ${isActive ? chalk().magenta(' (active)') : ''}`;
 
@@ -592,7 +592,7 @@ export const askForNewEmulator = async (c: RnvContext, platform: RnvPlatform) =>
     const { confirm } = await inquirerPrompt({
         name: 'confirm',
         type: 'confirm',
-        message: `Do you want ReNative to create new Emulator (${chalk().white(emuName)}) for you?`,
+        message: `Do you want ReNative to create new Emulator (${chalk().bold(emuName)}) for you?`,
     });
 
     if (!emuName) {
@@ -677,11 +677,11 @@ export const checkForActiveEmulator = (c: RnvContext, emulatorName?: string) =>
                         logDebug('Available devices after filtering', simsOnly);
                         const found = emulatorName && simsOnly.find((v) => v.name === emulatorName);
                         if (found) {
-                            logSuccess(`Found active emulator! ${chalk().white(found.udid)}. Will use it`);
+                            logSuccess(`Found active emulator! ${chalk().bold(found.udid)}. Will use it`);
                             clearInterval(poll);
                             resolve(found);
                         } else if (simsOnly.length > 0) {
-                            logSuccess(`Found active emulator! ${chalk().white(simsOnly[0].udid)}. Will use it`);
+                            logSuccess(`Found active emulator! ${chalk().bold(simsOnly[0].udid)}. Will use it`);
                             clearInterval(poll);
                             resolve(simsOnly[0]);
                         } else {

--- a/packages/sdk-android/src/gradleParser.ts
+++ b/packages/sdk-android/src/gradleParser.ts
@@ -294,7 +294,7 @@ def keystoreProps = new Properties()
 keystoreProps.load(new FileInputStream(keystorePropsFile))`;
         } else {
             logWarning(
-                `Your ${chalk().white(
+                `Your ${chalk().bold(
                     keystorePathFull
                 )} does not exist. You won't be able to make production releases without it!`
             );
@@ -304,11 +304,11 @@ keystoreProps.load(new FileInputStream(keystorePropsFile))`;
         if (!keyAlias) missingKeys.push('keyAlias');
         if (!storePassword) missingKeys.push('storePassword');
         if (!keyPassword) missingKeys.push('keyPassword');
-        logWarning(`You defined store file ${chalk().white(
+        logWarning(`You defined store file ${chalk().bold(
             storeFile
         )}, but you are missing following keys: ${chalk().red(missingKeys.join(', '))}
 Check your private files at:
-${chalk().white(c.paths.workspace?.appConfig?.configsPrivate?.join('\n'))}`);
+${chalk().bold(c.paths.workspace?.appConfig?.configsPrivate?.join('\n'))}`);
     }
 
     // BUILD_TYPES
@@ -780,7 +780,7 @@ const _fixAndroidLegacy = (c: RnvContext, modulePath: string) => {
 //             output.parentFolder = c.paths.workspace.appConfig.dir;
 //             output.path = privateConfigPath;
 //             logInfo(
-//                 `Found ${chalk().white(privateConfigPath)}. Will use it for production releases!`,
+//                 `Found ${chalk().bold(privateConfigPath)}. Will use it for production releases!`,
 //             );
 //             return output;
 //         } catch (e) {
@@ -789,7 +789,7 @@ const _fixAndroidLegacy = (c: RnvContext, modulePath: string) => {
 //         }
 //     } else {
 //         logWarning(
-//             `You're missing ${chalk().white(privateConfigPath)} for this app: . You won't be able to make production releases without it!`,
+//             `You're missing ${chalk().bold(privateConfigPath)} for this app: . You won't be able to make production releases without it!`,
 //         );
 //         return null;
 //     }

--- a/packages/sdk-android/src/installer.ts
+++ b/packages/sdk-android/src/installer.ts
@@ -142,7 +142,7 @@ const _attemptAutoFix = async (c: RnvContext, sdkPlatform: string, sdkKey: SDKKe
     }
 
     if (result) {
-        logSuccess(`Found existing ${chalk().white(sdkKey)} location at ${chalk().white(result)}`);
+        logSuccess(`Found existing ${chalk().bold(sdkKey)} location at ${chalk().bold(result)}`);
         let confirmSdk = true;
         if (!c.program.ci) {
             const { confirm } = await inquirerPrompt({
@@ -180,9 +180,9 @@ export const checkAndroidSdk = async (c: RnvContext) => {
     logDefault('checkAndroidSdk');
     if (!_isSdkInstalled(c)) {
         logWarning(
-            `${c.platform} requires SDK to be installed. Your SDK path in ${chalk().white(
+            `${c.platform} requires SDK to be installed. Your SDK path in ${chalk().bold(
                 c.paths.workspace.config
-            )} does not exist: ${chalk().white(_getCurrentSdkPath(c))}`
+            )} does not exist: ${chalk().bold(_getCurrentSdkPath(c))}`
         );
 
         switch (c.platform) {

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -203,9 +203,9 @@ const _checkSigningCerts = async (c: Context) => {
     if (isRelease && !c.payload.pluginConfigAndroid?.store?.storeFile) {
         const msg = `You're attempting to ${
             c.command
-        } app in release mode but you have't configured your ${chalk().white(
+        } app in release mode but you have't configured your ${chalk().bold(
             c.paths.workspace.appConfig.configPrivate
-        )} for ${chalk().white(c.platform)} platform yet.`;
+        )} for ${chalk().bold(c.platform)} platform yet.`;
         if (c.program.ci === true) {
             return Promise.reject(msg);
         }
@@ -256,9 +256,9 @@ const _checkSigningCerts = async (c: Context) => {
                         type: 'input',
                         name: 'storeFile',
                         default: './release.keystore',
-                        message: `Paste relative path to ${chalk().white(
+                        message: `Paste relative path to ${chalk().bold(
                             c.paths.workspace.appConfig.dir
-                        )} of your existing ${chalk().white('release.keystore')} file`,
+                        )} of your existing ${chalk().bold('release.keystore')} file`,
                     });
                     storeFile = result?.storeFile;
                 }
@@ -310,9 +310,7 @@ const _checkSigningCerts = async (c: Context) => {
             }
 
             updateObjectSync(c.paths.workspace.appConfig.configPrivate, c.files.workspace.appConfig.configPrivate);
-            logSuccess(
-                `Successfully updated private config file at ${chalk().white(c.paths.workspace.appConfig.dir)}.`
-            );
+            logSuccess(`Successfully updated private config file at ${chalk().bold(c.paths.workspace.appConfig.dir)}.`);
             // await configureProject(c);
             await updateRenativeConfigs(c);
             await parseAppBuildGradleSync(c);
@@ -387,7 +385,7 @@ export const configureProject = async (c: Context) => {
     const appFolder = getAppFolder(c);
 
     // if (!fsExistsSync(gradlew)) {
-    //     logWarning(`Your ${chalk().white(platform)} platformBuild is misconfigured!. let's repair it.`);
+    //     logWarning(`Your ${chalk().bold(platform)} platformBuild is misconfigured!. let's repair it.`);
     //     await createPlatformBuild(c, platform);
     //     await configureGradleProject(c);
 
@@ -476,7 +474,7 @@ export const configureProject = async (c: Context) => {
                             const fontDest = path.join(fontFolder, fontNormalised);
                             copyFileSync(fontSource, fontDest);
                         } else {
-                            logWarning(`Font ${chalk().white(fontSource)} doesn't exist! Skipping.`);
+                            logWarning(`Font ${chalk().bold(fontSource)} doesn't exist! Skipping.`);
                         }
                     }
                 }

--- a/packages/sdk-apple/src/__tests__/deviceManager.test.ts
+++ b/packages/sdk-apple/src/__tests__/deviceManager.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, executeAsync, createRnvContext } from '@rnv/core';
+import { executeAsync, createRnvContext } from '@rnv/core';
 import { utilities } from 'appium-ios-device';
 
 const simctlSimJson = {
@@ -136,7 +136,6 @@ jest.mock('@rnv/core');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/sdk-apple/src/__tests__/runner.test.ts
+++ b/packages/sdk-apple/src/__tests__/runner.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, inquirerPrompt, getContext, createRnvContext } from '@rnv/core';
+import { inquirerPrompt, getContext, createRnvContext } from '@rnv/core';
 import type { PromptParams } from '@rnv/core';
 import { getIosDeviceToRunOn } from '../runner';
 import { getAppleDevices } from '../deviceManager';
@@ -27,7 +27,6 @@ jest.mock('../deviceManager');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/sdk-apple/src/deviceManager.ts
+++ b/packages/sdk-apple/src/deviceManager.ts
@@ -195,11 +195,11 @@ export const launchAppleSimulator = async (c: RnvContext, target: string | boole
     }
 
     if (selectedDevice) {
-        logInfo(`Launching: ${chalk().white(selectedDevice.name)} (use -t to use different target)...`);
+        logInfo(`Launching: ${chalk().bold(selectedDevice.name)} (use -t to use different target)...`);
         await _launchSimulator(selectedDevice);
         return selectedDevice.name;
     } else if (target !== true && target !== undefined) {
-        logWarning(`Your specified simulator target ${chalk().white(target)} doesn't exist`);
+        logWarning(`Your specified simulator target ${chalk().bold(target)} doesn't exist`);
     }
     console.log('SSSSSSS3', devicesArr);
 

--- a/packages/sdk-apple/src/deviceManager.ts
+++ b/packages/sdk-apple/src/deviceManager.ts
@@ -96,7 +96,6 @@ const _parseNewIOSDevicesList = (
         }
         return 'Apple Device';
     };
-    console.log('SSSSSSS2', rawDevices);
 
     return rawDevices.map((device) => {
         const { DeviceName, ProductVersion, udid } = device;
@@ -201,7 +200,6 @@ export const launchAppleSimulator = async (c: RnvContext, target: string | boole
     } else if (target !== true && target !== undefined) {
         logWarning(`Your specified simulator target ${chalk().bold(target)} doesn't exist`);
     }
-    console.log('SSSSSSS3', devicesArr);
 
     const devices = devicesArr.map((v) => ({
         name: `${v.name} | ${v.icon} | v: ${chalk().green(v.version)} | udid: ${chalk().grey(v.udid)}${

--- a/packages/sdk-apple/src/objectiveCParser.ts
+++ b/packages/sdk-apple/src/objectiveCParser.ts
@@ -59,7 +59,7 @@ export const parseAppDelegate = (
         //     if (UI_COLORS.includes(backgroundColor)) {
         //         pluginBgColor = `vc.view.backgroundColor = UIColor.${backgroundColor}`;
         //     } else {
-        //         logWarning(`Your choosen color in renative.json for platform ${chalk().white(platform)} is not supported by UIColor. use one of the predefined ones: ${chalk().white(UI_COLORS.join(','))}`);
+        //         logWarning(`Your choosen color in renative.json for platform ${chalk().bold(platform)} is not supported by UIColor. use one of the predefined ones: ${chalk().bold(UI_COLORS.join(','))}`);
         //     }
         // }
 

--- a/packages/sdk-apple/src/provisionParser.ts
+++ b/packages/sdk-apple/src/provisionParser.ts
@@ -19,7 +19,7 @@ export const parseProvisioningProfiles = async (c: Context) => {
         return result;
     } catch (e) {
         logWarning(
-            `You have no provisioning files available. Check your ${chalk().white(
+            `You have no provisioning files available. Check your ${chalk().bold(
                 path.join(c.paths.home.dir, 'Library/MobileDevice/Provisioning Profiles')
             )} folder`
         );

--- a/packages/sdk-apple/src/runner.ts
+++ b/packages/sdk-apple/src/runner.ts
@@ -74,7 +74,7 @@ export const getIosDeviceToRunOn = async (c: Context) => {
     if (device === true) {
         if (devicesArr.length === 1) {
             logSuccess(
-                `Found one device connected! Device name: ${chalk().white(devicesArr[0].name)} udid: ${chalk().white(
+                `Found one device connected! Device name: ${chalk().bold(devicesArr[0].name)} udid: ${chalk().bold(
                     devicesArr[0].udid
                 )}`
             );
@@ -280,9 +280,9 @@ const _checkLockAndExec = async (
             if (isDeviceNotRegistered) {
                 logError(e);
                 logWarning(
-                    `${c.platform} DEVICE: ${chalk().white(c.runtime.target)} with UDID: ${chalk().white(
+                    `${c.platform} DEVICE: ${chalk().bold(c.runtime.target)} with UDID: ${chalk().bold(
                         c.runtime.targetUDID
-                    )} is not included in your provisionong profile in TEAM: ${chalk().white(
+                    )} is not included in your provisionong profile in TEAM: ${chalk().bold(
                         getConfigProp(c, c.platform, 'teamID')
                     )}`
                 );
@@ -321,14 +321,14 @@ const _checkLockAndExec = async (
 ${chalk().green('SUGGESTION:')}
 
 ${chalk().yellow('STEP 1:')}
-Open xcode workspace at: ${chalk().white(`${appPath}/${appFolderName}.xcworkspace`)}
+Open xcode workspace at: ${chalk().bold(`${appPath}/${appFolderName}.xcworkspace`)}
 
 ${chalk().yellow('STEP 2:')}
-${chalk().white('Run app and observe any extra errors')}
+${chalk().bold('Run app and observe any extra errors')}
 
 ${chalk().yellow('IF ALL HOPE IS LOST:')}
 Raise new issue and copy this SUMMARY box output at:
-${chalk().white('https://github.com/flexn-io/renative/issues')}
+${chalk().bold('https://github.com/flexn-io/renative/issues')}
 and we will try to help!
 
 `);
@@ -343,8 +343,8 @@ const _handleMissingTeam = async (c: Context, e: unknown) => {
         logError(e);
         logWarning(`You need specify the development team if you want to run app on ${
             c.platform
-        } device. this can be set manually in ${chalk().white(loc)}
-  You can find correct teamID in the URL of your apple developer account: ${chalk().white(
+        } device. this can be set manually in ${chalk().bold(loc)}
+  You can find correct teamID in the URL of your apple developer account: ${chalk().bold(
       'https://developer.apple.com/account/#/overview/YOUR-TEAM-ID'
   )}
 Type in your Apple Team ID to be used (will be saved to ${c.paths.appConfig?.config})`);
@@ -369,18 +369,18 @@ const _handleProvisioningIssues = async (c: Context, e: unknown, msg: string) =>
     const isProvAutomatic = provisioningStyle === 'Automatic';
     const proAutoText = isProvAutomatic
         ? ''
-        : `${chalk().white('[4]>')} Switch to automatic signing for appId: ${c.runtime.appId} , platform: ${
+        : `${chalk().bold('[4]>')} Switch to automatic signing for appId: ${c.runtime.appId} , platform: ${
               c.platform
           }, scheme: ${c.runtime.scheme}`;
     const fixCommand = `rnv crypto updateProfile -p ${c.platform} -s ${c.runtime.scheme}`;
-    const workspacePath = chalk().white(`${getAppFolder(c)}/${appFolderName}.xcworkspace`);
+    const workspacePath = chalk().bold(`${getAppFolder(c)}/${appFolderName}.xcworkspace`);
     logError(e);
     logWarning(`${msg}. To fix try:
-${chalk().white('[1]>')} Configure your certificates, provisioning profiles correctly manually
-${chalk().white('[2]>')} Try to generate matching profiles with ${chalk().white(
+${chalk().bold('[1]>')} Configure your certificates, provisioning profiles correctly manually
+${chalk().bold('[2]>')} Try to generate matching profiles with ${chalk().bold(
         fixCommand
     )} (you need correct priviledges in apple developer portal)
-${chalk().white(
+${chalk().bold(
     '[3]>'
 )} Open generated project in Xcode: ${workspacePath} and debug from there (Sometimes this helps for the first-time builds)
 ${proAutoText}`);
@@ -806,7 +806,7 @@ export const configureXcodeProject = async (c: Context) => {
                         c.payload.pluginConfigiOS.embeddedFonts.push(font);
                     }
                 } else {
-                    logWarning(`Font ${chalk().white(fontSource)} doesn't exist! Skipping.`);
+                    logWarning(`Font ${chalk().bold(fontSource)} doesn't exist! Skipping.`);
                 }
             }
         }
@@ -816,7 +816,7 @@ export const configureXcodeProject = async (c: Context) => {
     const tId = getConfigProp(c, platform, 'teamID');
     if (device && (!tId || tId === '')) {
         logError(
-            `You're missing teamID in your ${chalk().white(
+            `You're missing teamID in your ${chalk().bold(
                 c.paths.appConfig.config
             )} => .platforms.${platform}.teamID . you will not be able to build ${platform} app for device!`
         );

--- a/packages/sdk-apple/src/swiftParser.ts
+++ b/packages/sdk-apple/src/swiftParser.ts
@@ -65,7 +65,7 @@
 //         //     if (UI_COLORS.includes(backgroundColor)) {
 //         //         pluginBgColor = `vc.view.backgroundColor = UIColor.${backgroundColor}`;
 //         //     } else {
-//         //         logWarning(`Your choosen color in renative.json for platform ${chalk().white(platform)} is not supported by UIColor. use one of the predefined ones: ${chalk().white(UI_COLORS.join(','))}`);
+//         //         logWarning(`Your choosen color in renative.json for platform ${chalk().bold(platform)} is not supported by UIColor. use one of the predefined ones: ${chalk().bold(UI_COLORS.join(','))}`);
 //         //     }
 //         // }
 

--- a/packages/sdk-react-native/src/__tests__/env.test.ts
+++ b/packages/sdk-react-native/src/__tests__/env.test.ts
@@ -1,11 +1,10 @@
-import { createRnvApi, createRnvContext, getContext } from '@rnv/core';
+import { createRnvContext, getContext } from '@rnv/core';
 import { EnvVars } from '../env';
 
 jest.mock('@rnv/core');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/sdk-react-native/src/androidRunner.ts
+++ b/packages/sdk-react-native/src/androidRunner.ts
@@ -26,7 +26,7 @@ export const packageReactNativeAndroid = async (c: RnvContext) => {
     const bundleAssets = getConfigProp(c, platform, 'bundleAssets', false) === true;
 
     if (!bundleAssets && platform !== 'androidwear') {
-        logInfo(`bundleAssets in scheme ${chalk().white(c.runtime.scheme)} marked false. SKIPPING PACKAGING...`);
+        logInfo(`bundleAssets in scheme ${chalk().bold(c.runtime.scheme)} marked false. SKIPPING PACKAGING...`);
         return true;
     }
 

--- a/packages/sdk-react-native/src/common.ts
+++ b/packages/sdk-react-native/src/common.ts
@@ -120,7 +120,7 @@ export const configureFonts = async (c: RnvContext) => {
                     const fontFolder = fontSource.split('/').slice(0, -1).join('/');
                     fontFolders.add(fontFolder);
                 } else {
-                    logWarning(`Font ${chalk().white(fontSource)} doesn't exist! Skipping.`);
+                    logWarning(`Font ${chalk().bold(fontSource)} doesn't exist! Skipping.`);
                 }
             }
         }

--- a/packages/sdk-react-native/src/metroRunner.ts
+++ b/packages/sdk-react-native/src/metroRunner.ts
@@ -57,7 +57,7 @@ export const startReactNative = async (
     }
 
     if (c.program.resetHard || c.program.reset) {
-        logInfo(`You passed ${chalk().white('-r')} argument. --reset-cache will be applied to react-native`);
+        logInfo(`You passed ${chalk().bold('-r')} argument. --reset-cache will be applied to react-native`);
     }
     // logSummary('BUNDLER STARTED');
     const url = chalk().cyan(

--- a/packages/sdk-tizen/src/__tests__/runner.test.ts
+++ b/packages/sdk-tizen/src/__tests__/runner.test.ts
@@ -1,4 +1,4 @@
-import { createRnvApi, createRnvContext, execCLI, fsExistsSync, getContext } from '@rnv/core';
+import { createRnvContext, execCLI, fsExistsSync, getContext } from '@rnv/core';
 import { configureTizenGlobal, checkTizenStudioCert } from '../runner';
 import path from 'path';
 import { addDevelopTizenCertificate, createDevelopTizenCertificate } from '../deviceManager';
@@ -9,7 +9,6 @@ jest.mock('@rnv/core');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/sdk-tizen/src/deviceManager.ts
+++ b/packages/sdk-tizen/src/deviceManager.ts
@@ -309,7 +309,7 @@ export const runTizenSimOrDevice = async (
 
     // if (!platformConfig) {
     //     throw new Error(
-    //         `runTizen: ${chalk().grey(platform)} not defined in your ${chalk().white(c.paths.appConfig.config)}`
+    //         `runTizen: ${chalk().grey(platform)} not defined in your ${chalk().bold(c.paths.appConfig.config)}`
     //     );
     // }
 
@@ -317,7 +317,7 @@ export const runTizenSimOrDevice = async (
 
     if (!appName) {
         throw new Error(
-            `runTizen: ${chalk().grey(platform)}.appName not defined in your ${chalk().white(c.paths.appConfig.config)}`
+            `runTizen: ${chalk().grey(platform)}.appName not defined in your ${chalk().bold(c.paths.appConfig.config)}`
         );
     }
 

--- a/packages/sdk-tizen/src/installer.ts
+++ b/packages/sdk-tizen/src/installer.ts
@@ -67,7 +67,7 @@ const _attemptAutoFix = async (c: RnvContext) => {
     const result = SDK_LOCATIONS.find((v) => fsExistsSync(v));
 
     if (result) {
-        logSuccess(`Found existing ${c.platform} SDK location at ${chalk().white(result)}`);
+        logSuccess(`Found existing ${c.platform} SDK location at ${chalk().bold(result)}`);
         let confirmSdk = true;
         if (!c.program.ci) {
             const { confirm } = await inquirerPrompt({
@@ -106,9 +106,9 @@ export const checkTizenSdk = async (c: RnvContext) => {
     logDefault('checkTizenSdk');
     if (!_isSdkInstalled(c)) {
         logWarning(
-            `${c.platform} requires SDK to be installed. Your SDK path in ${chalk().white(
+            `${c.platform} requires SDK to be installed. Your SDK path in ${chalk().bold(
                 c.paths.workspace.config
-            )} does not exist: ${chalk().white(_getCurrentSdkPath(c))}`
+            )} does not exist: ${chalk().bold(_getCurrentSdkPath(c))}`
         );
 
         switch (c.platform) {

--- a/packages/sdk-tizen/src/runner.ts
+++ b/packages/sdk-tizen/src/runner.ts
@@ -135,7 +135,7 @@ export const runTizen = async (c: RnvContext, target?: string) => {
 
         if (!isPortActive) {
             logInfo(
-                `Your ${chalk().white(platform)} devServer at port ${chalk().white(
+                `Your ${chalk().bold(platform)} devServer at port ${chalk().bold(
                     c.runtime.port
                 )} is not running. Starting it up for you...`
             );

--- a/packages/sdk-utils/src/__tests__/index.test.ts
+++ b/packages/sdk-utils/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { getValidLocalhost, getDevServerHost, getAppVersionCode } from '../';
-import { DEFAULTS, createRnvApi, createRnvContext, getContext, getConfigProp } from '@rnv/core';
+import { DEFAULTS, createRnvContext, getContext, getConfigProp } from '@rnv/core';
 
 jest.mock('@rnv/core');
 jest.mock('axios');
@@ -12,7 +12,6 @@ jest.mock('color-string');
 
 beforeEach(() => {
     createRnvContext();
-    createRnvApi();
 });
 
 afterEach(() => {

--- a/packages/sdk-utils/src/index.ts
+++ b/packages/sdk-utils/src/index.ts
@@ -282,7 +282,7 @@ export const confirmActiveBundler = async (c: RnvContext) => {
         name: 'selectedOption',
         type: 'list',
         choices,
-        warningMessage: `Another ${c.platform} server at port ${chalk().white(c.runtime.port)} already running`,
+        warningMessage: `Another ${c.platform} server at port ${chalk().bold(c.runtime.port)} already running`,
     });
 
     if (choices[0] === selectedOption) {
@@ -309,7 +309,7 @@ export const addSystemInjects = (c: RnvContext, injects: OverridesOptions) => {
 
 export const sanitizeColor = (val: string | undefined, key: string) => {
     if (!val) {
-        logWarning(`You are missing ${chalk().white(key)} in your renative config. will use default #FFFFFF instead`);
+        logWarning(`You are missing ${chalk().bold(key)} in your renative config. will use default #FFFFFF instead`);
         return {
             rgb: [255, 255, 255, 1],
             rgbDecimal: [1, 1, 1, 1],

--- a/packages/sdk-webos/src/installer.ts
+++ b/packages/sdk-webos/src/installer.ts
@@ -88,7 +88,7 @@ const _attemptAutoFix = async (c: RnvContext) => {
     const result = SDK_LOCATIONS.find((v) => fsExistsSync(v));
 
     if (result) {
-        logSuccess(`Found existing ${c.platform} SDK location at ${chalk().white(result)}`);
+        logSuccess(`Found existing ${c.platform} SDK location at ${chalk().bold(result)}`);
         let confirmSdk = true;
         if (!c.program.ci) {
             const { confirm } = await inquirerPrompt({
@@ -128,9 +128,9 @@ export const checkWebosSdk = async (c: RnvContext) => {
     logDefault('checkWebosSdk');
     if (!_isSdkInstalled(c)) {
         logWarning(
-            `${c.platform} requires SDK to be installed. Your SDK path in ${chalk().white(
+            `${c.platform} requires SDK to be installed. Your SDK path in ${chalk().bold(
                 c.paths.workspace.config
-            )} does not exist: ${chalk().white(_getCurrentSdkPath(c))}`
+            )} does not exist: ${chalk().bold(_getCurrentSdkPath(c))}`
         );
 
         switch (c.platform) {

--- a/packages/sdk-webos/src/runner.ts
+++ b/packages/sdk-webos/src/runner.ts
@@ -87,7 +87,7 @@ export const runWebOS = async (c: RnvContext) => {
 
         if (!isPortActive) {
             logInfo(
-                `Your ${chalk().white(platform)} devServer at port ${chalk().white(
+                `Your ${chalk().bold(platform)} devServer at port ${chalk().bold(
                     c.runtime.port
                 )} is not running. Starting it up for you...`
             );

--- a/packages/sdk-webpack/src/index.ts
+++ b/packages/sdk-webpack/src/index.ts
@@ -103,7 +103,7 @@ Debugger running at: ${debugUrl}`);
         \n<script src="http://${resolvedDebugIp}:${REMOTE_DEBUG_PORT}/target.js"></script>`;
     } catch (e) {
         logWarning(
-            `You are missing chii. You can install via ${chalk().white('npm i -g chii')}) Trying to use weinre next`
+            `You are missing chii. You can install via ${chalk().bold('npm i -g chii')}) Trying to use weinre next`
         );
     }
 
@@ -140,7 +140,7 @@ Debugger running at: ${debugUrl}`);
             c.platform
         }"></script>`;
     } catch (e) {
-        logWarning(`You are missing weinre. Skipping debug. install via ${chalk().white('npm i -g weinre')}`);
+        logWarning(`You are missing weinre. Skipping debug. install via ${chalk().bold('npm i -g weinre')}`);
     }
     return true;
 };
@@ -244,7 +244,7 @@ export const runWebpackServer = async (c: RnvContext, enableRemoteDebugger?: boo
 
     if (!isPortActive) {
         logInfo(
-            `Your ${chalk().white(platform)} devServerHost ${chalk().white(devServerHost)} at port ${chalk().white(
+            `Your ${chalk().bold(platform)} devServerHost ${chalk().bold(devServerHost)} at port ${chalk().bold(
                 port
             )} is not running. Starting it up for you...`
         );


### PR DESCRIPTION
## Description
- Allows unknown cli options for integrations, since they're not known when `commander` is being set up.
- Adds some TODO comments for other cli issues.
- update cli logging
- allow integrations to have single command tasks 
- fix relative path printouts

How to test integration:

```shell
cd packages/app-harness
rnv starter hello -p ios --my-opt=hello

# prints: Hello from Integration Starter!
# --my-opt: "hello"
```

```shell
cd packages/app-harness
rnv starter-single-command -p ios --my-opt=hello

# prints: Hello from Integration Starter!
# --my-opt: "hello"
```
<img width="611" alt="Screenshot 2024-03-07 at 01 25 26" src="https://github.com/flexn-io/renative/assets/4638697/acf8a436-ee69-4070-ae81-ce08dc940443">

<img width="637" alt="Screenshot 2024-03-07 at 01 25 37" src="https://github.com/flexn-io/renative/assets/4638697/a530442c-ed98-4ab7-a5ef-18d574f919fb">



TODO NOTES:

– integrations can't use options that rnv uses, like "--version", because rnv just prints its version and exits. => this is standard behavior of most CLIs so it's more about conventions 
– when using `executeAsync()`, spaces must be manually escaped. 

## Related issues

n/a

## Npm releases

n/a
