### PR TITLE
Fix: Add missing RN_HOST_METHODS injection to android templates

### DIFF
--- a/packages/engine-rn-tvos/templates/platforms/androidtv/app/src/main/java/rnv_template/MainApplication.kt
+++ b/packages/engine-rn-tvos/templates/platforms/androidtv/app/src/main/java/rnv_template/MainApplication.kt
@@ -28,6 +28,8 @@ class MainApplication : Application(), ReactApplication {
 
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+        {{RN_HOST_METHODS}}
       }
 
   {{PLUGIN_METHODS}}

--- a/packages/engine-rn-tvos/templates/platforms/firetv/app/src/main/java/rnv_template/MainApplication.kt
+++ b/packages/engine-rn-tvos/templates/platforms/firetv/app/src/main/java/rnv_template/MainApplication.kt
@@ -28,6 +28,8 @@ class MainApplication : Application(), ReactApplication {
 
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+        {{RN_HOST_METHODS}}
       }
 
   {{PLUGIN_METHODS}}

--- a/packages/engine-rn/templates/platforms/android/app/src/main/java/rnv_template/MainApplication.kt
+++ b/packages/engine-rn/templates/platforms/android/app/src/main/java/rnv_template/MainApplication.kt
@@ -31,6 +31,8 @@ class MainApplication : Application(), ReactApplication {
 
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+        {{RN_HOST_METHODS}}
       }
 
 {{PLUGIN_METHODS}}

--- a/packages/engine-rn/templates/platforms/androidwear/app/src/main/java/rnv_template/MainApplication.kt
+++ b/packages/engine-rn/templates/platforms/androidwear/app/src/main/java/rnv_template/MainApplication.kt
@@ -31,6 +31,8 @@ class MainApplication : Application(), ReactApplication {
 
         override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
         override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED
+
+        {{RN_HOST_METHODS}}
       }
 
 {{PLUGIN_METHODS}}


### PR DESCRIPTION
## Description

`{{RN_HOST_METHODS}}` was accidentally removed in one of previuos commits, but it has working functionality in [kotlinParser](https://github.com/flexn-io/renative/blob/66ac5efa19fc138c685175b675c783900f46e878/packages/sdk-android/src/kotlinParser.ts#L98). Adding it back for all android based platforms.
