### PR TITLE
Add back INJECT_PLUGIN_PATHS, INJECT_POST_INSTALL

### DIFF
--- a/packages/engine-rn-tvos/templates/platforms/tvos/Podfile
+++ b/packages/engine-rn-tvos/templates/platforms/tvos/Podfile
@@ -52,6 +52,8 @@ target 'RNVApp-tvOS' do
   config = use_native_modules!
   platform :tvos, '{{INJECT_PLUGIN_DEPLOYMENT_TARGET}}'
 
+  {{INJECT_PLUGIN_PATHS}}
+
   use_react_native!(
     :path => config[:reactNativePath],
     # Enables Flipper.
@@ -79,6 +81,7 @@ post_install do |installer|
     config[:reactNativePath],
     :mac_catalyst_enabled => false
   )
+  {{INJECT_POST_INSTALL}}
 end
 
 {{INJECT_PLUGIN_PODFILE_INJECT}}

--- a/packages/engine-rn/templates/platforms/ios/Podfile
+++ b/packages/engine-rn/templates/platforms/ios/Podfile
@@ -36,6 +36,8 @@ end
 
 target 'RNVApp' do
   config = use_native_modules!
+
+  {{INJECT_PLUGIN_PATHS}}
   
   use_react_native!(
     :path => config[:reactNativePath],
@@ -62,6 +64,7 @@ target 'RNVApp' do
       config[:reactNativePath],
       :mac_catalyst_enabled => false
     )
+    {{INJECT_POST_INSTALL}}
   end
 end
 


### PR DESCRIPTION
## Description

- Add back INJECT_PLUGIN_PATHS, INJECT_POST_INSTALL injections

Testcase:
- `npx rnv run -p ios -s debug-static-pods` should succeed. For this scheme there are 2 extra plugins added, react-native-firebase and react-native-photo-editor. Both need the injections to work. The build will fail otherwise. 

## Related issues

- n/a

## Npm releases

n/a
