### PR TITLE
fix generateBuildConfig

### DIFF
--- a/packages/core/src/configs/buildConfig.ts
+++ b/packages/core/src/configs/buildConfig.ts
@@ -185,4 +185,19 @@ export const generateBuildConfig = (_c?: RnvContext) => {
             logWarning('Cannot save buildConfig as c.paths.project.builds.dir is not defined');
         }
     }
+
+    _checkBuildSchemeIfEngine(c);
+};
+
+const _checkBuildSchemeIfEngine = (c: RnvContext) => {
+    const { scheme } = c.program;
+    if (!c.platform || !scheme) return;
+
+    const platform = c.buildConfig?.platforms?.[c.platform];
+    if (!platform) return;
+
+    const definedEngine = platform.buildSchemes?.[scheme]?.engine;
+    if (definedEngine) {
+        platform.engine = definedEngine;
+    }
 };


### PR DESCRIPTION
## Description

- Overriding engine in buildSchemes have no effect.

To check, run `npx rnv run -p web -s debug-engine-rn-web` in app-harness. 

Rnv should use **engine-rn-web** instead default one  (engine-rn-next).

## Related issues

- https://github.com/flexn-io/renative/issues/1414

## Npm releases

n/a
