### PR TITLE
CLI fixes

### DIFF
--- a/packages/app-harness/src/entry/index.web.ts
+++ b/packages/app-harness/src/entry/index.web.ts
@@ -1,5 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from '../app';
-
-ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/packages/app-harness/src/entry/index.web.tsx
+++ b/packages/app-harness/src/entry/index.web.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from '../app';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
+);

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -240,27 +240,27 @@ export const logSummary = (header = '✔ SUMMARY') => {
 
     // str += printIntoBox(`ReNative Version: ${_highlightColor(ctx.rnvVersion)}`);
     if (ctx.files?.project?.package?.name && ctx.files?.project?.package?.version) {
-        str += printIntoBox(`Project Name ($package.name): ${_highlightColor(ctx.files.project.package.name)}`);
         str += printIntoBox(
-            `Project Version ($package.version): ${_highlightColor(ctx.files.project.package.version)}`
+            `Project: ${currentChalk.gray(`${ctx.files.project.package.name}@${ctx.files.project.package.version}`)}`
         );
+        // str += printIntoBox(`Project Version: ${currentChalk.gray(ctx.files.project.package.version)}`);
     }
 
     if (ctx.buildConfig?.workspaceID) {
-        str += printIntoBox(`Workspace ($.workspaceID): ${_highlightColor(ctx.buildConfig.workspaceID)}`);
+        str += printIntoBox(`Workspace: ${currentChalk.gray(ctx.buildConfig.workspaceID)}`);
     }
     if (ctx.platform) {
         str += printIntoBox(`Platform (-p): ${_highlightColor(ctx.platform)}`);
     }
     if (ctx.runtime?.engine) {
-        let addon = '';
-        if (ctx.platform) {
-            addon = ` ($.platforms.${ctx.platform}.engine)`;
-        }
-        str += printIntoBox(`Engine${addon}: ${_highlightColor(ctx.runtime?.engine?.config?.id || '')}`);
+        // let addon = '';
+        // if (ctx.platform) {
+        //     addon = ` ($.platforms.${ctx.platform}.engine)`;
+        // }
+        str += printIntoBox(`Engine: ${_highlightColor(ctx.runtime?.engine?.config?.id || '')}`);
     }
     if (ctx.runtime?.activeTemplate) {
-        str += printIntoBox(`Template: ${_highlightColor(ctx.runtime?.activeTemplate)}`);
+        str += printIntoBox(`Template: ${currentChalk.gray(ctx.runtime?.activeTemplate)}`);
     }
     if (ctx.buildConfig?._meta?.currentAppConfigId) {
         str += printIntoBox(`App Config (-c): ${_highlightColor(ctx.buildConfig._meta?.currentAppConfigId)}`);
@@ -283,7 +283,9 @@ export const logSummary = (header = '✔ SUMMARY') => {
         str += printIntoBox(`Reset Project and Assets (-R): ${_highlightColor(!!ctx.program?.resetHard)}`);
     }
     if (ctx.runtime?.supportedPlatforms?.length) {
-        const plats = ctx.runtime.supportedPlatforms.map((v) => `${v.platform}${v.isConnected ? '' : '(ejected)'}`);
+        const plats = ctx.runtime.supportedPlatforms.map(
+            (v) => `${currentChalk.gray(v.platform)}${v.isConnected ? '' : '(ejected)'}`
+        );
         str += printArrIntoBox(plats, 'Supported Platforms: ');
     }
 
@@ -293,7 +295,9 @@ export const logSummary = (header = '✔ SUMMARY') => {
     }
 
     if (ctx.timeEnd) {
-        str += printIntoBox(`Executed Time: ${_msToTime(ctx.timeEnd.getTime() - ctx.timeStart.getTime())}`);
+        str += printIntoBox(
+            `Executed Time: ${currentChalk.gray(_msToTime(ctx.timeEnd.getTime() - ctx.timeStart.getTime()))}`
+        );
     }
 
     // str += printIntoBox('');
@@ -302,8 +306,9 @@ export const logSummary = (header = '✔ SUMMARY') => {
 
     // str += printIntoBox('');
     if (ctx.runtime?.platformBuildsProjectPath) {
-        str += printIntoBox('Project location:');
-        str += printIntoBox(`${currentChalk.bold(_sanitizePaths(ctx.runtime.platformBuildsProjectPath || ''))}`);
+        str += printIntoBox(
+            `Project location: ${currentChalk.gray(_sanitizePaths(ctx.runtime.platformBuildsProjectPath || ''))}`
+        );
     }
     str += printBoxEnd();
 

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -257,7 +257,7 @@ export const logSummary = (header = '✔ SUMMARY') => {
         // if (ctx.platform) {
         //     addon = ` ($.platforms.${ctx.platform}.engine)`;
         // }
-        str += printIntoBox(`Engine: ${_highlightColor(ctx.runtime?.engine?.config?.id || '')}`);
+        str += printIntoBox(`Engine: ${currentChalk.gray(ctx.runtime?.engine?.config?.id || '')}`);
     }
     if (ctx.runtime?.activeTemplate) {
         str += printIntoBox(`Template: ${currentChalk.gray(ctx.runtime?.activeTemplate)}`);

--- a/packages/cli/src/logger/index.ts
+++ b/packages/cli/src/logger/index.ts
@@ -10,6 +10,7 @@ import {
     RnvApiChalk,
     RnvApiChalkFn,
 } from '@rnv/core';
+import path from 'path';
 
 const ICN_ROCKET = isSystemWin ? 'RNV' : '🚀';
 // const ICN_UNICORN = isSystemWin ? 'unicorn' : '🦄';
@@ -326,9 +327,20 @@ const _getCurrentTask = () => {
     return ctx._currentTask ? currentChalk.grey(`○ ${ctx._currentTask}:`) : '';
 };
 
-const CWD = process.cwd();
-const CWD_UP = CWD.split('/').slice(0, -1).join('/');
-const CWD_UP_UP = CWD.split('/').slice(0, -2).join('/');
+const CWD_ARR: { path: string; relative: string }[] = [];
+
+const _generateRelativePaths = () => {
+    const cwd = process.cwd();
+    const cwdArr = cwd.split(path.sep);
+    let relativeUp = '.';
+    for (let i = 1; i < cwdArr.length; i++) {
+        const absoluteUp = path.join(cwd, relativeUp).normalize();
+        CWD_ARR.push({ path: absoluteUp, relative: relativeUp });
+        relativeUp += i > 1 ? '/..' : '.';
+    }
+};
+
+_generateRelativePaths();
 
 const _sanitizePaths = (msg: string) => {
     // const ctx = getContext();
@@ -339,10 +351,13 @@ const _sanitizePaths = (msg: string) => {
     // }
 
     if (msg?.replace) {
-        return msg
-            .replace(new RegExp(CWD, 'g'), '.')
-            .replace(new RegExp(CWD_UP, 'g'), '..')
-            .replace(new RegExp(CWD_UP_UP, 'g'), '../..');
+        CWD_ARR.forEach((v) => {
+            msg = msg.replace(new RegExp(v.path, 'g'), v.relative);
+        });
+        // return msg
+        //     .replace(new RegExp(CWD, 'g'), '.')
+        //     .replace(new RegExp(CWD_UP, 'g'), '..')
+        //     .replace(new RegExp(CWD_UP_UP, 'g'), '../..');
     }
     return msg;
 };
@@ -583,7 +598,7 @@ export const logEnd = (code: number) => {
 
 export const logAppInfo = (c: RnvContext) => {
     if (!_jsonOnly) {
-        logInfo(`Current App Config: ${currentChalk.bold(c.runtime.appId)}`);
+        logInfo(`Current app config: ${currentChalk.bold(c.runtime.appId)}`);
     }
 };
 

--- a/packages/core/jsonSchema/rnv.app.json
+++ b/packages/core/jsonSchema/rnv.app.json
@@ -3239,349 +3239,356 @@
           "additionalProperties": {
             "anyOf": [
               {
-                "type": "object",
-                "properties": {
-                  "disabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Marks plugin disabled"
-                  },
-                  "props": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Custom props passed to plugin"
-                  },
-                  "version": {
-                    "type": "string",
-                    "description": "Version of plugin. Typically package version"
-                  },
-                  "deprecated": {
-                    "type": "string",
-                    "description": "Marks your plugin deprecated with warning showing in the console during rnv commands"
-                  },
-                  "source": {
-                    "type": "string",
-                    "description": "Will define custom scope for your plugin config to extend from.\n\nNOTE: custom scopes can be defined via paths.pluginTemplates.[CUSTOM_SCOPE].{}"
-                  },
-                  "disableNpm": {
-                    "type": "boolean",
-                    "description": "Will skip including plugin in package.json and installing it via npm/yarn etc"
-                  },
-                  "skipMerge": {
-                    "type": "boolean",
-                    "description": "Will not attempt to merge with existing plugin configuration (ie. coming form renative pluginTemplates)\n\nNOTE: if set to `true` you need to configure your plugin object fully"
-                  },
-                  "npm": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Object of npm dependencies of this plugin. These will be injected into package.json"
-                  },
-                  "pluginDependencies": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "description": "List of other Renative plugins this plugin depends on"
-                  },
-                  "webpackConfig": {
+                "anyOf": [
+                  {
                     "type": "object",
                     "properties": {
-                      "modulePaths": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
+                      "disabled": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Marks plugin disabled"
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Custom props passed to plugin"
+                      },
+                      "version": {
+                        "type": "string",
+                        "description": "Version of plugin. Typically package version"
+                      },
+                      "deprecated": {
+                        "type": "string",
+                        "description": "Marks your plugin deprecated with warning showing in the console during rnv commands"
+                      },
+                      "source": {
+                        "type": "string",
+                        "description": "Will define custom scope for your plugin config to extend from.\n\nNOTE: custom scopes can be defined via paths.pluginTemplates.[CUSTOM_SCOPE].{}"
+                      },
+                      "disableNpm": {
+                        "type": "boolean",
+                        "description": "Will skip including plugin in package.json and installing it via npm/yarn etc"
+                      },
+                      "skipMerge": {
+                        "type": "boolean",
+                        "description": "Will not attempt to merge with existing plugin configuration (ie. coming form renative pluginTemplates)\n\nNOTE: if set to `true` you need to configure your plugin object fully"
+                      },
+                      "npm": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Object of npm dependencies of this plugin. These will be injected into package.json"
+                      },
+                      "pluginDependencies": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": "List of other Renative plugins this plugin depends on"
+                      },
+                      "webpackConfig": {
+                        "type": "object",
+                        "properties": {
+                          "modulePaths": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
                           },
-                          {
+                          "moduleAliases": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "projectPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "projectPath"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          "nextTranspileModules": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             }
                           }
-                        ]
+                        },
+                        "additionalProperties": false,
+                        "description": "Allows you to configure webpack bahaviour per each individual plugin"
                       },
-                      "moduleAliases": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "object",
-                            "additionalProperties": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "projectPath": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "projectPath"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              ]
-                            }
-                          }
-                        ]
+                      "disablePluginTemplateOverrides": {
+                        "type": "boolean",
+                        "description": "Disables plugin overrides for selected plugin"
                       },
-                      "nextTranspileModules": {
+                      "fontSources": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         }
-                      }
-                    },
-                    "additionalProperties": false,
-                    "description": "Allows you to configure webpack bahaviour per each individual plugin"
-                  },
-                  "disablePluginTemplateOverrides": {
-                    "type": "boolean",
-                    "description": "Disables plugin overrides for selected plugin"
-                  },
-                  "fontSources": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "android": {
-                    "type": "object",
-                    "properties": {
-                      "disabled": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Marks plugin platform disabled"
                       },
-                      "forceLinking": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Packages that cannot be autolinked yet can still be added to MainApplication PackageList dynamically by setting this to true"
-                      },
-                      "path": {
-                        "type": "string",
-                        "description": "Enables you to pass custom path to plugin. If undefined, the default `node_modules/[plugin-name]` will be used."
-                      },
-                      "projectName": {
-                        "type": "string"
-                      },
-                      "skipLinking": {
-                        "type": "boolean"
-                      },
-                      "skipImplementation": {
-                        "type": "boolean"
-                      },
-                      "implementation": {
-                        "type": "string"
-                      },
-                      "package": {
-                        "type": "string"
-                      },
-                      "templateAndroid": {
+                      "android": {
                         "type": "object",
                         "properties": {
-                          "gradle_properties": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/gradle_properties"
+                          "disabled": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Marks plugin platform disabled"
                           },
-                          "build_gradle": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/build_gradle"
+                          "forceLinking": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Packages that cannot be autolinked yet can still be added to MainApplication PackageList dynamically by setting this to true"
                           },
-                          "app_build_gradle": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/app_build_gradle"
+                          "path": {
+                            "type": "string",
+                            "description": "Enables you to pass custom path to plugin. If undefined, the default `node_modules/[plugin-name]` will be used."
                           },
-                          "AndroidManifest_xml": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/AndroidManifest_xml"
+                          "projectName": {
+                            "type": "string"
                           },
-                          "strings_xml": {
+                          "skipLinking": {
+                            "type": "boolean"
+                          },
+                          "skipImplementation": {
+                            "type": "boolean"
+                          },
+                          "implementation": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "type": "string"
+                          },
+                          "templateAndroid": {
                             "type": "object",
                             "properties": {
-                              "children": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "tag": {
-                                      "type": "string"
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "child_value": {
-                                      "type": "string"
+                              "gradle_properties": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/gradle_properties"
+                              },
+                              "build_gradle": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/build_gradle"
+                              },
+                              "app_build_gradle": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/app_build_gradle"
+                              },
+                              "AndroidManifest_xml": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/AndroidManifest_xml"
+                              },
+                              "strings_xml": {
+                                "type": "object",
+                                "properties": {
+                                  "children": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "tag": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "child_value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "tag",
+                                        "name",
+                                        "child_value"
+                                      ],
+                                      "additionalProperties": false
                                     }
-                                  },
-                                  "required": [
-                                    "tag",
-                                    "name",
-                                    "child_value"
-                                  ],
-                                  "additionalProperties": false
-                                }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "MainActivity_java": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/MainActivity_java"
+                              },
+                              "MainApplication_java": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/MainApplication_java"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "androidtv": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android"
+                      },
+                      "androidwear": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android"
+                      },
+                      "firetv": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android"
+                      },
+                      "ios": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/disabled"
+                          },
+                          "forceLinking": {
+                            "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/forceLinking"
+                          },
+                          "path": {
+                            "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/path"
+                          },
+                          "git": {
+                            "type": "string",
+                            "description": "Alternative git url for pod instead of version"
+                          },
+                          "commit": {
+                            "type": "string",
+                            "description": "Alternative git commit reference string"
+                          },
+                          "version": {
+                            "type": "string",
+                            "description": "Version of pod"
+                          },
+                          "podNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "podName": {
+                            "type": "string"
+                          },
+                          "staticFrameworks": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "templateXcode": {
+                            "type": "object",
+                            "properties": {
+                              "Podfile": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/Podfile"
+                              },
+                              "project_pbxproj": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/project_pbxproj"
+                              },
+                              "AppDelegate_mm": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_mm"
+                              },
+                              "AppDelegate_h": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_h"
+                              },
+                              "Info_plist": {
+                                "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/Info_plist"
                               }
                             },
                             "additionalProperties": false
                           },
-                          "MainActivity_java": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/MainActivity_java"
+                          "isStatic": {
+                            "type": "boolean"
                           },
-                          "MainApplication_java": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/templateAndroid/properties/MainApplication_java"
+                          "buildType": {
+                            "type": "string",
+                            "enum": [
+                              "dynamic",
+                              "static"
+                            ],
+                            "description": "Build type of the pod"
                           }
                         },
                         "additionalProperties": false
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "androidtv": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android"
-                  },
-                  "androidwear": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android"
-                  },
-                  "firetv": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android"
-                  },
-                  "ios": {
-                    "type": "object",
-                    "properties": {
-                      "disabled": {
-                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/disabled"
                       },
-                      "forceLinking": {
-                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/forceLinking"
+                      "tvos": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/ios"
                       },
-                      "path": {
-                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/path"
-                      },
-                      "git": {
-                        "type": "string",
-                        "description": "Alternative git url for pod instead of version"
-                      },
-                      "commit": {
-                        "type": "string",
-                        "description": "Alternative git commit reference string"
-                      },
-                      "version": {
-                        "type": "string",
-                        "description": "Version of pod"
-                      },
-                      "podNames": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "podName": {
-                        "type": "string"
-                      },
-                      "staticFrameworks": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "templateXcode": {
+                      "tizen": {
                         "type": "object",
                         "properties": {
-                          "Podfile": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/Podfile"
+                          "disabled": {
+                            "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/disabled"
                           },
-                          "project_pbxproj": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/project_pbxproj"
+                          "forceLinking": {
+                            "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/forceLinking"
                           },
-                          "AppDelegate_mm": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_mm"
-                          },
-                          "AppDelegate_h": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_h"
-                          },
-                          "Info_plist": {
-                            "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/templateXcode/properties/Info_plist"
+                          "path": {
+                            "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/path"
                           }
                         },
                         "additionalProperties": false
                       },
-                      "isStatic": {
-                        "type": "boolean"
+                      "tizenmobile": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
                       },
-                      "buildType": {
-                        "type": "string",
-                        "enum": [
-                          "dynamic",
-                          "static"
-                        ],
-                        "description": "Build type of the pod"
+                      "tizenwatch": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "webos": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "web": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "webtv": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "chromecast": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "kaios": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "macos": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "linux": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "windows": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "xbox": {
+                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
                       }
                     },
                     "additionalProperties": false
                   },
-                  "tvos": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/ios"
-                  },
-                  "tizen": {
-                    "type": "object",
-                    "properties": {
-                      "disabled": {
-                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/disabled"
-                      },
-                      "forceLinking": {
-                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/forceLinking"
-                      },
-                      "path": {
-                        "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/path"
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "tizenmobile": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "tizenwatch": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "webos": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "web": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "webtv": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "chromecast": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "kaios": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "macos": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "linux": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "windows": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "xbox": {
-                    "$ref": "#/definitions/rnv.app/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
+                  {
+                    "type": "string"
                   }
-                },
-                "additionalProperties": false
+                ]
               },
               {
-                "type": "string"
+                "type": "null"
               }
             ]
           },

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -19,6 +19,28 @@
           "type": "boolean",
           "description": "Mark if your project is part of monorepo"
         },
+        "useTemplate": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "excludedPaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "name",
+            "version"
+          ],
+          "additionalProperties": false
+        },
         "isTemplate": {
           "type": "boolean"
         },

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -3616,349 +3616,356 @@
           "additionalProperties": {
             "anyOf": [
               {
-                "type": "object",
-                "properties": {
-                  "disabled": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Marks plugin disabled"
-                  },
-                  "props": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Custom props passed to plugin"
-                  },
-                  "version": {
-                    "type": "string",
-                    "description": "Version of plugin. Typically package version"
-                  },
-                  "deprecated": {
-                    "type": "string",
-                    "description": "Marks your plugin deprecated with warning showing in the console during rnv commands"
-                  },
-                  "source": {
-                    "type": "string",
-                    "description": "Will define custom scope for your plugin config to extend from.\n\nNOTE: custom scopes can be defined via paths.pluginTemplates.[CUSTOM_SCOPE].{}"
-                  },
-                  "disableNpm": {
-                    "type": "boolean",
-                    "description": "Will skip including plugin in package.json and installing it via npm/yarn etc"
-                  },
-                  "skipMerge": {
-                    "type": "boolean",
-                    "description": "Will not attempt to merge with existing plugin configuration (ie. coming form renative pluginTemplates)\n\nNOTE: if set to `true` you need to configure your plugin object fully"
-                  },
-                  "npm": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Object of npm dependencies of this plugin. These will be injected into package.json"
-                  },
-                  "pluginDependencies": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "description": "List of other Renative plugins this plugin depends on"
-                  },
-                  "webpackConfig": {
+                "anyOf": [
+                  {
                     "type": "object",
                     "properties": {
-                      "modulePaths": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
+                      "disabled": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Marks plugin disabled"
+                      },
+                      "props": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Custom props passed to plugin"
+                      },
+                      "version": {
+                        "type": "string",
+                        "description": "Version of plugin. Typically package version"
+                      },
+                      "deprecated": {
+                        "type": "string",
+                        "description": "Marks your plugin deprecated with warning showing in the console during rnv commands"
+                      },
+                      "source": {
+                        "type": "string",
+                        "description": "Will define custom scope for your plugin config to extend from.\n\nNOTE: custom scopes can be defined via paths.pluginTemplates.[CUSTOM_SCOPE].{}"
+                      },
+                      "disableNpm": {
+                        "type": "boolean",
+                        "description": "Will skip including plugin in package.json and installing it via npm/yarn etc"
+                      },
+                      "skipMerge": {
+                        "type": "boolean",
+                        "description": "Will not attempt to merge with existing plugin configuration (ie. coming form renative pluginTemplates)\n\nNOTE: if set to `true` you need to configure your plugin object fully"
+                      },
+                      "npm": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "description": "Object of npm dependencies of this plugin. These will be injected into package.json"
+                      },
+                      "pluginDependencies": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "description": "List of other Renative plugins this plugin depends on"
+                      },
+                      "webpackConfig": {
+                        "type": "object",
+                        "properties": {
+                          "modulePaths": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            ]
                           },
-                          {
+                          "moduleAliases": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "projectPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "projectPath"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          "nextTranspileModules": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             }
                           }
-                        ]
+                        },
+                        "additionalProperties": false,
+                        "description": "Allows you to configure webpack bahaviour per each individual plugin"
                       },
-                      "moduleAliases": {
-                        "anyOf": [
-                          {
-                            "type": "boolean"
-                          },
-                          {
-                            "type": "object",
-                            "additionalProperties": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "projectPath": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "projectPath"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              ]
-                            }
-                          }
-                        ]
+                      "disablePluginTemplateOverrides": {
+                        "type": "boolean",
+                        "description": "Disables plugin overrides for selected plugin"
                       },
-                      "nextTranspileModules": {
+                      "fontSources": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         }
-                      }
-                    },
-                    "additionalProperties": false,
-                    "description": "Allows you to configure webpack bahaviour per each individual plugin"
-                  },
-                  "disablePluginTemplateOverrides": {
-                    "type": "boolean",
-                    "description": "Disables plugin overrides for selected plugin"
-                  },
-                  "fontSources": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "android": {
-                    "type": "object",
-                    "properties": {
-                      "disabled": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Marks plugin platform disabled"
                       },
-                      "forceLinking": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Packages that cannot be autolinked yet can still be added to MainApplication PackageList dynamically by setting this to true"
-                      },
-                      "path": {
-                        "type": "string",
-                        "description": "Enables you to pass custom path to plugin. If undefined, the default `node_modules/[plugin-name]` will be used."
-                      },
-                      "projectName": {
-                        "type": "string"
-                      },
-                      "skipLinking": {
-                        "type": "boolean"
-                      },
-                      "skipImplementation": {
-                        "type": "boolean"
-                      },
-                      "implementation": {
-                        "type": "string"
-                      },
-                      "package": {
-                        "type": "string"
-                      },
-                      "templateAndroid": {
+                      "android": {
                         "type": "object",
                         "properties": {
-                          "gradle_properties": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/gradle_properties"
+                          "disabled": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Marks plugin platform disabled"
                           },
-                          "build_gradle": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/build_gradle"
+                          "forceLinking": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Packages that cannot be autolinked yet can still be added to MainApplication PackageList dynamically by setting this to true"
                           },
-                          "app_build_gradle": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/app_build_gradle"
+                          "path": {
+                            "type": "string",
+                            "description": "Enables you to pass custom path to plugin. If undefined, the default `node_modules/[plugin-name]` will be used."
                           },
-                          "AndroidManifest_xml": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/AndroidManifest_xml"
+                          "projectName": {
+                            "type": "string"
                           },
-                          "strings_xml": {
+                          "skipLinking": {
+                            "type": "boolean"
+                          },
+                          "skipImplementation": {
+                            "type": "boolean"
+                          },
+                          "implementation": {
+                            "type": "string"
+                          },
+                          "package": {
+                            "type": "string"
+                          },
+                          "templateAndroid": {
                             "type": "object",
                             "properties": {
-                              "children": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "tag": {
-                                      "type": "string"
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "child_value": {
-                                      "type": "string"
+                              "gradle_properties": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/gradle_properties"
+                              },
+                              "build_gradle": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/build_gradle"
+                              },
+                              "app_build_gradle": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/app_build_gradle"
+                              },
+                              "AndroidManifest_xml": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/AndroidManifest_xml"
+                              },
+                              "strings_xml": {
+                                "type": "object",
+                                "properties": {
+                                  "children": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "tag": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "child_value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "tag",
+                                        "name",
+                                        "child_value"
+                                      ],
+                                      "additionalProperties": false
                                     }
-                                  },
-                                  "required": [
-                                    "tag",
-                                    "name",
-                                    "child_value"
-                                  ],
-                                  "additionalProperties": false
-                                }
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "MainActivity_java": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/MainActivity_java"
+                              },
+                              "MainApplication_java": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/MainApplication_java"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "androidtv": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android"
+                      },
+                      "androidwear": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android"
+                      },
+                      "firetv": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android"
+                      },
+                      "ios": {
+                        "type": "object",
+                        "properties": {
+                          "disabled": {
+                            "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/disabled"
+                          },
+                          "forceLinking": {
+                            "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/forceLinking"
+                          },
+                          "path": {
+                            "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/path"
+                          },
+                          "git": {
+                            "type": "string",
+                            "description": "Alternative git url for pod instead of version"
+                          },
+                          "commit": {
+                            "type": "string",
+                            "description": "Alternative git commit reference string"
+                          },
+                          "version": {
+                            "type": "string",
+                            "description": "Version of pod"
+                          },
+                          "podNames": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "podName": {
+                            "type": "string"
+                          },
+                          "staticFrameworks": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "templateXcode": {
+                            "type": "object",
+                            "properties": {
+                              "Podfile": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/Podfile"
+                              },
+                              "project_pbxproj": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/project_pbxproj"
+                              },
+                              "AppDelegate_mm": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_mm"
+                              },
+                              "AppDelegate_h": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_h"
+                              },
+                              "Info_plist": {
+                                "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/Info_plist"
                               }
                             },
                             "additionalProperties": false
                           },
-                          "MainActivity_java": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/MainActivity_java"
+                          "isStatic": {
+                            "type": "boolean"
                           },
-                          "MainApplication_java": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/templateAndroid/properties/MainApplication_java"
+                          "buildType": {
+                            "type": "string",
+                            "enum": [
+                              "dynamic",
+                              "static"
+                            ],
+                            "description": "Build type of the pod"
                           }
                         },
                         "additionalProperties": false
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "androidtv": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android"
-                  },
-                  "androidwear": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android"
-                  },
-                  "firetv": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android"
-                  },
-                  "ios": {
-                    "type": "object",
-                    "properties": {
-                      "disabled": {
-                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/disabled"
                       },
-                      "forceLinking": {
-                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/forceLinking"
+                      "tvos": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/ios"
                       },
-                      "path": {
-                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/path"
-                      },
-                      "git": {
-                        "type": "string",
-                        "description": "Alternative git url for pod instead of version"
-                      },
-                      "commit": {
-                        "type": "string",
-                        "description": "Alternative git commit reference string"
-                      },
-                      "version": {
-                        "type": "string",
-                        "description": "Version of pod"
-                      },
-                      "podNames": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "podName": {
-                        "type": "string"
-                      },
-                      "staticFrameworks": {
-                        "type": "array",
-                        "items": {
-                          "type": "string"
-                        }
-                      },
-                      "templateXcode": {
+                      "tizen": {
                         "type": "object",
                         "properties": {
-                          "Podfile": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/Podfile"
+                          "disabled": {
+                            "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/disabled"
                           },
-                          "project_pbxproj": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/project_pbxproj"
+                          "forceLinking": {
+                            "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/forceLinking"
                           },
-                          "AppDelegate_mm": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_mm"
-                          },
-                          "AppDelegate_h": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/AppDelegate_h"
-                          },
-                          "Info_plist": {
-                            "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/templateXcode/properties/Info_plist"
+                          "path": {
+                            "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/android/properties/path"
                           }
                         },
                         "additionalProperties": false
                       },
-                      "isStatic": {
-                        "type": "boolean"
+                      "tizenmobile": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
                       },
-                      "buildType": {
-                        "type": "string",
-                        "enum": [
-                          "dynamic",
-                          "static"
-                        ],
-                        "description": "Build type of the pod"
+                      "tizenwatch": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "webos": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "web": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "webtv": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "chromecast": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "kaios": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "macos": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "linux": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "windows": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
+                      },
+                      "xbox": {
+                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/anyOf/0/properties/tizen"
                       }
                     },
                     "additionalProperties": false
                   },
-                  "tvos": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/ios"
-                  },
-                  "tizen": {
-                    "type": "object",
-                    "properties": {
-                      "disabled": {
-                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/disabled"
-                      },
-                      "forceLinking": {
-                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/forceLinking"
-                      },
-                      "path": {
-                        "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/android/properties/path"
-                      }
-                    },
-                    "additionalProperties": false
-                  },
-                  "tizenmobile": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "tizenwatch": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "webos": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "web": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "webtv": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "chromecast": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "kaios": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "macos": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "linux": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "windows": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
-                  },
-                  "xbox": {
-                    "$ref": "#/definitions/rnv.project/properties/plugins/additionalProperties/anyOf/0/properties/tizen"
+                  {
+                    "type": "string"
                   }
-                },
-                "additionalProperties": false
+                ]
               },
               {
-                "type": "string"
+                "type": "null"
               }
             ]
           },

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -415,6 +415,104 @@
         "runtime": {
           "description": "This object will be automatically injected into `./platfromAssets/renative.runtime.json` making it possible to inject the values directly to JS source code"
         },
+        "templateConfig": {
+          "type": "object",
+          "properties": {
+            "includedPaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Defines list of all file/dir paths you want to include in template"
+            },
+            "bootstrapQuestions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "title": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "object",
+                          "properties": {},
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "title",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "configProp": {
+                    "type": "object",
+                    "properties": {
+                      "prop": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "prop",
+                      "key"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "title"
+                ],
+                "additionalProperties": false
+              },
+              "description": "Defines list of custom bootstrap questions"
+            },
+            "packageTemplate": {
+              "type": "object",
+              "properties": {
+                "dependencies": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "devDependencies": {
+                  "$ref": "#/definitions/rnv.project/properties/templateConfig/properties/packageTemplate/properties/dependencies"
+                },
+                "peerDependencies": {
+                  "$ref": "#/definitions/rnv.project/properties/templateConfig/properties/packageTemplate/properties/dependencies"
+                },
+                "optionalDependencies": {
+                  "$ref": "#/definitions/rnv.project/properties/templateConfig/properties/packageTemplate/properties/dependencies"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false,
+          "description": "Used in `renative.template.json` allows you to define template behaviour."
+        },
         "skipAutoUpdate": {
           "type": "boolean",
           "description": "Enables the equivalent to passing --skipDependencyCheck parameter on every rnv run so you don't have to use it"

--- a/packages/core/jsonSchema/rnv.template.json
+++ b/packages/core/jsonSchema/rnv.template.json
@@ -217,9 +217,6 @@
               "additionalProperties": false
             }
           },
-          "required": [
-            "bootstrapQuestions"
-          ],
           "additionalProperties": false,
           "description": "Used in `renative.template.json` allows you to define template behaviour."
         },

--- a/packages/core/src/engines/index.ts
+++ b/packages/core/src/engines/index.ts
@@ -378,7 +378,7 @@ export const loadEngines = async (c: RnvContext, failOnMissingDeps?: boolean): P
             }
         } else {
             readyEngines.push(k);
-            logInfo(`Engine ${k} found at ${engineRootPath}`);
+            logInfo(`Load engine: ${k} ${chalk().gray(`(${engineRootPath})`)}`);
             engineConfigs.push({
                 key: k,
                 engineRootPath,

--- a/packages/core/src/engines/index.ts
+++ b/packages/core/src/engines/index.ts
@@ -378,6 +378,7 @@ export const loadEngines = async (c: RnvContext, failOnMissingDeps?: boolean): P
             }
         } else {
             readyEngines.push(k);
+            logInfo(`Engine ${k} found at ${engineRootPath}`);
             engineConfigs.push({
                 key: k,
                 engineRootPath,

--- a/packages/core/src/engines/index.ts
+++ b/packages/core/src/engines/index.ts
@@ -21,6 +21,7 @@ const ENGINE_CORE = 'engine-core';
 export const registerEngine = async (engine: RnvEngine, platform?: RnvPlatform, engConfig?: RnvEngineTemplate) => {
     const c = getContext();
     logDefault(`registerEngine:${engine.config.id}`);
+
     c.runtime.enginesById[engine.config.id] = engine;
 
     c.runtime.enginesByIndex.push(engine);
@@ -139,6 +140,7 @@ export const registerMissingPlatformEngines = async (c: RnvContext, taskInstance
 
 export const registerAllPlatformEngines = async (c: RnvContext) => {
     logDefault('registerAllPlatformEngines');
+
     if (!c.buildConfig?.defaults?.supportedPlatforms?.forEach) {
         c.runtime.hasAllEnginesRegistered = true;
         return true;
@@ -472,8 +474,10 @@ const _resolvePkgPath = (c: RnvContext, packageName: string) => {
 
 const _registerPlatformEngine = async (c: RnvContext, platform: RnvPlatform | boolean): Promise<void> => {
     // Only register active platform engine to be faster
+
     if (platform === true || !platform) return;
     const selectedEngineTemplate = getEngineTemplateByPlatform(c, platform);
+
     if (selectedEngineTemplate) {
         const existingEngine = c.runtime.enginesById[selectedEngineTemplate.id];
         if (!existingEngine) {
@@ -522,7 +526,9 @@ export const hasEngineTask = (task: string, tasks: RnvTaskMap, isProjectScope?: 
     isProjectScope ? !!getEngineTask(task, tasks) : getEngineTask(task, tasks)?.isGlobalScope;
 
 export const getEngineSubTasks = (task: string, tasks: RnvTaskMap, exactMatch?: boolean) =>
-    Object.values(tasks).filter((v) => (exactMatch ? v.task.split(' ')[0] === task : v.task.startsWith(task)));
+    Object.values(tasks).filter((v) =>
+        exactMatch ? v.task.split(' ')[0] === task : v.task.split(' ')[0].startsWith(task)
+    );
 
 export const getEngineRunner = (c: RnvContext, task: string, customTasks?: RnvTaskMap, failOnMissingEngine = true) => {
     if (customTasks?.[task]) {

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -619,18 +619,10 @@ const _overridePlugin = (c: RnvContext, pluginsPath: string, dir: string) => {
     }
 
     if (flavourSource && fsExistsSync(flavourSource)) {
-        logInfo(
-            `${chalk().bold(dest.split('node_modules').pop())} overriden by: ${chalk().bold(
-                flavourSource.split('node_modules').pop()
-            )}`
-        );
+        logInfo(`${chalk().gray(dest)} overriden by: ${chalk().gray(flavourSource.split('node_modules').pop())}`);
         copyFolderContentsRecursiveSync(flavourSource, dest, false);
     } else if (fsExistsSync(source)) {
-        logInfo(
-            `${chalk().bold(dest.split('node_modules').pop())} overriden by: ${chalk().bold(
-                source.split('node_modules').pop()
-            )}`
-        );
+        logInfo(`${chalk().gray(dest)} overriden by: ${chalk().gray(source.split('node_modules').pop())}`);
         copyFolderContentsRecursiveSync(source, dest, false);
         // fsReaddirSync(pp).forEach((dir) => {
         //     copyFileSync(path.resolve(pp, file), path.resolve(c.paths.project.dir, 'node_modules', dir));
@@ -707,9 +699,7 @@ export const overrideFileContents = (dest: string, override: Record<string, stri
                 } else {
                     foundRegEx = true;
                     logInfo(
-                        `${chalk().bold(dest.split('node_modules').pop())} overriden by: ${chalk().bold(
-                            overridePath.split('node_modules').pop()
-                        )}`
+                        `${chalk().gray(dest)} overriden by: ${chalk().gray(overridePath.split('node_modules').pop())}`
                     );
                 }
             } else {

--- a/packages/core/src/projects/index.ts
+++ b/packages/core/src/projects/index.ts
@@ -467,7 +467,7 @@ export const copyAssetsFolder = async (
     // FOLDER MERGERS FROM EXTERNAL SOURCES
     if (validAssetSources.length > 0) {
         logInfo(
-            `Found custom assetSources at ${chalk().bold(
+            `Found custom assetSources at ${chalk().gray(
                 validAssetSources.join('/n')
             )}. Will be used to generate assets.`
         );

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -18,6 +18,14 @@ export const executeRnvCore = async () => {
     if (c.program.npxMode) {
         return;
     }
+
+    // Special Case for engine-core tasks
+    // they don't require other engines to be loaded if isGlobalScope = true
+    const initTask = await findSuitableTask(c);
+    if (initTask?.task && initTask.isGlobalScope) {
+        return initializeTask(c, initTask?.task);
+    }
+
     await loadIntegrations(c);
     const result = await loadEngines(c);
 

--- a/packages/core/src/runner.ts
+++ b/packages/core/src/runner.ts
@@ -4,7 +4,7 @@ import { loadIntegrations } from './integrations';
 import { checkAndMigrateProject } from './migrator';
 import { checkAndBootstrapIfRequired } from './projects';
 import { configureRuntimeDefaults } from './context/runtime';
-import { findSuitableTask, initializeTask } from './tasks';
+import { findSuitableGlobalTask, findSuitableTask, initializeTask } from './tasks';
 import { updateRenativeConfigs } from './plugins';
 
 export const executeRnvCore = async () => {
@@ -21,14 +21,14 @@ export const executeRnvCore = async () => {
 
     // Special Case for engine-core tasks
     // they don't require other engines to be loaded if isGlobalScope = true
-    const initTask = await findSuitableTask(c);
+    // ie rnv link
+    const initTask = await findSuitableGlobalTask();
     if (initTask?.task && initTask.isGlobalScope) {
         return initializeTask(c, initTask?.task);
     }
 
     await loadIntegrations(c);
     const result = await loadEngines(c);
-
     // If false make sure we reload configs as it means it's freshly installed
     if (!result) {
         await updateRenativeConfigs(c);
@@ -42,6 +42,7 @@ export const executeRnvCore = async () => {
 
     // Some tasks might require all engines to be present (ie rnv platform list)
     const taskInstance = await findSuitableTask(c);
+
     if (c.command && !taskInstance?.ignoreEngines) {
         await registerMissingPlatformEngines(c, taskInstance);
     }

--- a/packages/core/src/schema/configFiles/project.ts
+++ b/packages/core/src/schema/configFiles/project.ts
@@ -1,6 +1,6 @@
 import { AnyZodObject, z } from 'zod';
 import { CommonSchema } from '../common';
-import { Ext, ExtendTemplate, PlatformsKeys, Runtime } from '../shared';
+import { Ext, ExtendTemplate, PlatformsKeys, Runtime, TemplateConfig } from '../shared';
 import { PlatformsSchema } from '../platforms';
 import { PluginsSchema } from '../plugins';
 
@@ -236,6 +236,7 @@ const RootProjectBaseFragment = {
     integrations: z.optional(Integrations),
     env: z.optional(Env),
     runtime: z.optional(Runtime),
+    templateConfig: TemplateConfig.optional(),
     skipAutoUpdate: z
         .boolean()
         .optional()

--- a/packages/core/src/schema/configFiles/project.ts
+++ b/packages/core/src/schema/configFiles/project.ts
@@ -205,6 +205,12 @@ const Paths = z
     })
     .describe('Define custom paths for RNV to look into');
 
+const UseTemplate = z.object({
+    name: z.string(),
+    version: z.string(),
+    excludedPaths: z.optional(z.array(z.string())),
+});
+
 //LEVEl 0 (ROOT)
 
 const RootProjectBaseFragment = {
@@ -212,6 +218,7 @@ const RootProjectBaseFragment = {
     projectVersion: z.string(),
     projectName: ProjectName,
     isMonorepo: z.optional(IsMonoRepo),
+    useTemplate: z.optional(UseTemplate),
     isTemplate: z.boolean().optional(),
     defaults: z.optional(DefaultsSchema),
     pipes: z.optional(Pipes),

--- a/packages/core/src/schema/configFiles/template.ts
+++ b/packages/core/src/schema/configFiles/template.ts
@@ -1,54 +1,11 @@
 import { z } from 'zod';
 import { DefaultsSchema, EnginesSchema } from './project';
-
-const NpmDep = z.record(z.string(), z.string());
-
-const BootstrapQuestionsSchema = z
-    .array(
-        z.object({
-            options: z
-                .array(
-                    z.object({
-                        title: z.string(),
-                        value: z.object({}),
-                    })
-                )
-                .optional(),
-            configProp: z
-                .object({
-                    prop: z.string(),
-                    key: z.string(),
-                })
-                .optional(),
-            type: z.string(),
-            title: z.string(),
-        })
-    )
-    .describe('Defines list of custom bootstrap questions');
+import { TemplateConfig } from '../shared';
 
 export const RootTemplateSchema = z.object({
     defaults: z.optional(DefaultsSchema),
     engines: z.optional(EnginesSchema),
-    templateConfig: z
-        .object({
-            includedPaths: z
-                .array(z.string())
-                .describe('Defines list of all file/dir paths you want to include in template')
-                .optional(),
-            bootstrapQuestions: BootstrapQuestionsSchema,
-            packageTemplate: z.optional(
-                z.object({
-                    dependencies: z.optional(NpmDep),
-                    devDependencies: z.optional(NpmDep),
-                    peerDependencies: z.optional(NpmDep),
-                    optionalDependencies: z.optional(NpmDep),
-                    name: z.string().optional(),
-                    version: z.string().optional(),
-                })
-            ),
-        })
-        .describe('Used in `renative.template.json` allows you to define template behaviour.')
-        .optional(),
+    templateConfig: TemplateConfig.optional(),
 });
 
 // {

--- a/packages/core/src/schema/plugins/index.ts
+++ b/packages/core/src/schema/plugins/index.ts
@@ -57,7 +57,7 @@ export type _PluginPlatformMergedSchemaType = z.infer<typeof PluginPlatformMerge
 export type _PluginType = z.infer<typeof PluginSchema>;
 
 export const PluginsSchema = z
-    .record(z.string(), z.union([PluginSchema, z.string()]))
+    .record(z.string(), z.union([PluginSchema, z.string()]).nullable())
     .describe(
         'Define all plugins available in your project. you can then use `includedPlugins` and `excludedPlugins` props to define active and inactive plugins per each app config'
     );

--- a/packages/core/src/schema/shared/index.ts
+++ b/packages/core/src/schema/shared/index.ts
@@ -41,3 +41,48 @@ export const BuildSchemeFragment = {
             )
     ),
 };
+
+const NpmDep = z.record(z.string(), z.string());
+
+const BootstrapQuestionsSchema = z
+    .array(
+        z.object({
+            options: z
+                .array(
+                    z.object({
+                        title: z.string(),
+                        value: z.object({}),
+                    })
+                )
+                .optional(),
+            configProp: z
+                .object({
+                    prop: z.string(),
+                    key: z.string(),
+                })
+                .optional(),
+            type: z.string(),
+            title: z.string(),
+        })
+    )
+    .describe('Defines list of custom bootstrap questions');
+
+export const TemplateConfig = z
+    .object({
+        includedPaths: z
+            .array(z.string())
+            .describe('Defines list of all file/dir paths you want to include in template')
+            .optional(),
+        bootstrapQuestions: BootstrapQuestionsSchema.optional(),
+        packageTemplate: z.optional(
+            z.object({
+                dependencies: z.optional(NpmDep),
+                devDependencies: z.optional(NpmDep),
+                peerDependencies: z.optional(NpmDep),
+                optionalDependencies: z.optional(NpmDep),
+                name: z.string().optional(),
+                version: z.string().optional(),
+            })
+        ),
+    })
+    .describe('Used in `renative.template.json` allows you to define template behaviour.');

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -30,6 +30,11 @@ export const registerCustomTask = async (_c: RnvContext, task: RnvTask) => {
 
 export const initializeTask = async (c: RnvContext, task: string) => {
     logDefault('initializeTask', task);
+    logInfo(
+        `Current engine: ${chalk().bold(c.runtime.engine?.config.id)} ${chalk().grey(
+            `(${c.runtime.engine?.rootPath})`
+        )}`
+    );
     c.runtime.task = task;
     executedTasks = {};
 
@@ -308,11 +313,6 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
             c.runtime.runtimeExtraProps = c.runtime.engine.runtimeExtraProps;
         }
 
-        logInfo(
-            `Current Engine: ${chalk().bold(c.runtime.engine?.config.id)} path: ${chalk().grey(
-                c.runtime.engine?.rootPath
-            )}`
-        );
         const customTask = CUSTOM_TASKS[task];
         if (customTask) {
             c.runtime.availablePlatforms = customTask.platforms;

--- a/packages/core/src/tasks/index.ts
+++ b/packages/core/src/tasks/index.ts
@@ -281,7 +281,7 @@ export const findSuitableTask = async (c: RnvContext, specificTask?: string): Pr
 
         if (CUSTOM_TASKS[task]) {
             // Custom tasks are executed by core engine
-            logInfo(`Running custom task ${task}`);
+            logInfo(`Running custom task ${chalk().bold(task)}`);
         } else if (!suitableEngines.length) {
             if (!c.runtime.hasAllEnginesRegistered) {
                 // No platform was specified. we have no option other than load all engines and offer platform list next round

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -174,15 +174,8 @@ const _configureRenativeConfig = async (c: RnvContext) => {
         logInfo(
             `Your ${c.paths.project.config} needs to be updated with ${c.paths.template.configTemplate}. UPDATING...DONE`
         );
-        if (c.files.project.config_original && templateConfig) {
-            const mergedObj = mergeObjects<ConfigFileTemplate & ConfigFileProject>(
-                c,
-                templateConfig,
-                c.files.project.config_original,
-                false,
-                true
-            );
-
+        const mergedObj = getProjectTemplateMergedConfig(c, templateConfig);
+        if (mergedObj) {
             // Do not override supportedPlatforms
             mergedObj.defaults = mergedObj.defaults || {};
             mergedObj.defaults.supportedPlatforms = c.files.project.config_original?.defaults?.supportedPlatforms;
@@ -205,20 +198,30 @@ const _configureRenativeConfig = async (c: RnvContext) => {
     return true;
 };
 
+const getProjectTemplateMergedConfig = (c: RnvContext, templateConfig: ConfigFileTemplate | null) => {
+    if (c.files.project.config_original && templateConfig) {
+        const mergedObj = mergeObjects<ConfigFileTemplate & ConfigFileProject>(
+            c,
+            templateConfig,
+            c.files.project.config_original,
+            false,
+            true
+        );
+        return mergedObj;
+    }
+    return null;
+};
+
 export const configureTemplateFiles = async (c: RnvContext) => {
     logDefault('configureTemplateFiles');
 
     const templateConfig = readObjectSync<ConfigFileTemplate>(c.paths.template.configTemplate);
 
-    const includedPaths = templateConfig?.templateConfig?.includedPaths;
-    const excludedPaths = c.buildConfig.useTemplate?.excludedPaths;
+    let mergedObj = getProjectTemplateMergedConfig(c, templateConfig);
+    const includedPaths = mergedObj?.templateConfig?.includedPaths;
 
     if (includedPaths) {
         includedPaths.forEach((name: string) => {
-            if (excludedPaths && excludedPaths.includes(name)) {
-                logDebug(`Skipping file ${chalk().bold(name)} due to exclusion`);
-                return;
-            }
             if (c.paths.template.dir) {
                 const sourcePath = path.join(c.paths.template.dir, name);
                 const destPath = path.join(c.paths.project.dir, name);

--- a/packages/core/src/templates/index.ts
+++ b/packages/core/src/templates/index.ts
@@ -211,8 +211,14 @@ export const configureTemplateFiles = async (c: RnvContext) => {
     const templateConfig = readObjectSync<ConfigFileTemplate>(c.paths.template.configTemplate);
 
     const includedPaths = templateConfig?.templateConfig?.includedPaths;
+    const excludedPaths = c.buildConfig.useTemplate?.excludedPaths;
+
     if (includedPaths) {
         includedPaths.forEach((name: string) => {
+            if (excludedPaths && excludedPaths.includes(name)) {
+                logDebug(`Skipping file ${chalk().bold(name)} due to exclusion`);
+                return;
+            }
             if (c.paths.template.dir) {
                 const sourcePath = path.join(c.paths.template.dir, name);
                 const destPath = path.join(c.paths.project.dir, name);

--- a/packages/engine-core/src/buildSchemes.ts
+++ b/packages/engine-core/src/buildSchemes.ts
@@ -55,6 +55,6 @@ export const isBuildSchemeSupported = async (c: RnvContext) => {
         c.program.scheme = schemeVals[selectedScheme];
         c.runtime.scheme = c.program.scheme;
     }
-    logInfo(`Current Build Scheme: ${chalk().bold.white(c.runtime.scheme)}`);
+    logInfo(`Current Build Scheme: ${chalk().bold(c.runtime.scheme)}`);
     return true;
 };

--- a/packages/engine-core/src/tasks/global/taskNew.ts
+++ b/packages/engine-core/src/tasks/global/taskNew.ts
@@ -158,7 +158,7 @@ const _prepareProjectOverview = (c: RnvContext, data: NewProjectData) => {
     data.confirmString = str;
 };
 
-type ConfigProp = Required<ConfigFileTemplate>['templateConfig']['bootstrapQuestions'][number]['configProp'];
+type ConfigProp = Required<Required<ConfigFileTemplate>['templateConfig']>['bootstrapQuestions'][number]['configProp'];
 
 type QuestionResults = Record<
     string,
@@ -169,7 +169,7 @@ type QuestionResults = Record<
     }
 >;
 
-type BootstrapQuestions = Required<ConfigFileTemplate>['templateConfig']['bootstrapQuestions'];
+type BootstrapQuestions = Required<Required<ConfigFileTemplate>['templateConfig']>['bootstrapQuestions'];
 
 const interactiveQuestion = async (
     results: QuestionResults,

--- a/packages/engine-core/src/tasks/linking/taskLink.ts
+++ b/packages/engine-core/src/tasks/linking/taskLink.ts
@@ -21,6 +21,13 @@ const _linkPackage = (c: RnvContext, key: string, folder: string) => {
 
     if (fsExistsSync(rnvPathUnlinked)) {
         logInfo(`${key} is already linked. SKIPPING`);
+
+        try {
+            fsSymlinkSync(pkgDir, rnvPath);
+        } catch (e) {
+            // In case of corrupted symlinks we attempt to relink
+            // however existing symlinks will throw error
+        }
     } else if (fsExistsSync(rnvPath)) {
         fsRenameSync(rnvPath, rnvPathUnlinked);
         fsSymlinkSync(pkgDir, rnvPath);

--- a/packages/engine-lightning/src/tasks/taskRun.ts
+++ b/packages/engine-lightning/src/tasks/taskRun.ts
@@ -39,6 +39,7 @@ const Task: RnvTask = {
     fn: taskRun,
     fnHelp: taskRunHelp,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     // dependencies: {
     //     before: RnvTaskName.configure,
     // },

--- a/packages/engine-rn-electron/src/tasks/taskRun.ts
+++ b/packages/engine-rn-electron/src/tasks/taskRun.ts
@@ -35,6 +35,7 @@ const Task: RnvTask = {
     description: 'Run your electron app on your machine',
     fn: taskRun,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     options: RnvTaskOptionPresets.withBase(RnvTaskOptionPresets.withConfigure(RnvTaskOptionPresets.withRun())),
     platforms: ['macos', 'windows', 'linux'],
 };

--- a/packages/engine-rn-macos/src/tasks/taskRun.ts
+++ b/packages/engine-rn-macos/src/tasks/taskRun.ts
@@ -54,6 +54,7 @@ const Task: RnvTask = {
     fn: taskRun,
     fnHelp: taskRunHelp,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     // dependencies: {
     //     before: RnvTaskName.configure,
     // },

--- a/packages/engine-rn-next/renative.engine.json
+++ b/packages/engine-rn-next/renative.engine.json
@@ -8,6 +8,7 @@
         "react-art": "source:rnv",
         "react-dom": "source:rnv",
         "react-native": "source:rnv",
+        "react-native-web": "source:rnv",
         "next": "source:rnv"
     },
     "npm": {

--- a/packages/engine-rn-next/renative.engine.json
+++ b/packages/engine-rn-next/renative.engine.json
@@ -8,7 +8,6 @@
         "react-art": "source:rnv",
         "react-dom": "source:rnv",
         "react-native": "source:rnv",
-        "react-native-web": "source:rnv",
         "next": "source:rnv"
     },
     "npm": {

--- a/packages/engine-rn-next/src/tasks/taskRun.ts
+++ b/packages/engine-rn-next/src/tasks/taskRun.ts
@@ -32,6 +32,7 @@ const Task: RnvTask = {
     description: 'Run your app in browser',
     fn: taskRun,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     options: RnvTaskOptionPresets.withBase(RnvTaskOptionPresets.withConfigure(RnvTaskOptionPresets.withRun())),
     platforms: ['web', 'chromecast'],
 };

--- a/packages/engine-rn-tvos/renative.engine.json
+++ b/packages/engine-rn-tvos/renative.engine.json
@@ -9,8 +9,7 @@
         "react-art": "source:rnv",
         "react-dom": "source:rnv",
         "react-native": "source:rnv",
-        "react-native-tvos": "source:rnv",
-        "react-native-web": "source:rnv"
+        "react-native-tvos": "source:rnv"
     },
     "npm": {
         "devDependencies": {}

--- a/packages/engine-rn-tvos/src/tasks/taskRun.ts
+++ b/packages/engine-rn-tvos/src/tasks/taskRun.ts
@@ -73,6 +73,7 @@ const Task: RnvTask = {
     fn: taskRun,
     fnHelp: taskRunHelp,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     // dependencies: {
     //     before: RnvTaskName.configure,
     // },

--- a/packages/engine-rn-web/src/tasks/taskRun.ts
+++ b/packages/engine-rn-web/src/tasks/taskRun.ts
@@ -128,6 +128,7 @@ const Task: RnvTask = {
     description: 'Run your app in browser',
     fn: taskRun,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     options: RnvTaskOptionPresets.withBase(RnvTaskOptionPresets.withConfigure(RnvTaskOptionPresets.withRun())),
     platforms: ['web', 'webtv', 'tizen', 'webos', 'tizenmobile', 'tizenwatch', 'kaios', 'chromecast'],
 };

--- a/packages/engine-rn-windows/src/tasks/taskRun.ts
+++ b/packages/engine-rn-windows/src/tasks/taskRun.ts
@@ -40,6 +40,7 @@ const Task: RnvTask = {
     description: 'Run your app in a window on desktop',
     fn: taskRun,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     options: RnvTaskOptionPresets.withBase(RnvTaskOptionPresets.withConfigure(RnvTaskOptionPresets.withRun())),
     platforms: ['windows', 'xbox'],
 };

--- a/packages/engine-rn/src/tasks/taskRun.ts
+++ b/packages/engine-rn/src/tasks/taskRun.ts
@@ -78,6 +78,7 @@ const Task: RnvTask = {
     fn: taskRun,
     fnHelp: taskRunHelp,
     task: RnvTaskName.run,
+    isPriorityOrder: true,
     // dependencies: {
     //     before: RnvTaskName.configure,
     // },

--- a/packages/rnv/pluginTemplates/renative.plugins.json
+++ b/packages/rnv/pluginTemplates/renative.plugins.json
@@ -1,12 +1,37 @@
 {
     "$schema": "../../../.rnv/schema/rnv.plugins.json",
+    "comments": [
+        "This is the main configuration file for RNV plugins. It allows you to define which plugins you want to use and their versions.",
+        "It also acts as override against @flexn/plugins"
+    ],
     "pluginTemplates": {
         "@rnv/renative": {
-            "version": "1.0.0-rc.12",
-            "webpack": {
-                "moduleAliases": true,
+            "version": "1.0.0-rc.12"
+        },
+        "react-native-tvos": {
+            "version": "0.73.1-3"
+        },
+        "react-native-web": {
+            "version": "0.19.9",
+            "webpackConfig": {
                 "modulePaths": true
             }
+        },
+        "next": {
+            "version": "14.1.0",
+            "disablePluginTemplateOverrides": true
+        },
+        "react-native": {
+            "version": "0.73.4"
+        },
+        "@react-native-community/cli-platform-ios": {
+            "version": "11.3.7",
+            "disablePluginTemplateOverrides": false,
+            "disableNpm": true
+        },
+        "react-native-gesture-handler": {
+            "version": "2.14.1",
+            "disablePluginTemplateOverrides": true
         }
     }
 }

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -135,40 +135,16 @@
         }
     },
     "plugins": {
-        "@rnv/renative": {
-            "source": "rnv",
-            "webpackConfig": {
-                "modulePaths": true
-            }
-        },
+        "@rnv/renative": "source:rnv",
         "react": "source:rnv",
         "react-art": "source:rnv",
         "react-dom": "source:rnv",
-        "react-native-gesture-handler": {
-            "version": "2.14.1",
-            "disablePluginTemplateOverrides": true
-        },
-        "@react-native-community/cli-platform-ios": {
-            "version": "11.3.7",
-            "disablePluginTemplateOverrides": false,
-            "disableNpm": true
-        },
-        "react-native": {
-            "version": "0.73.4"
-        },
-        "next": {
-            "version": "14.1.0",
-            "disablePluginTemplateOverrides": true
-        },
-        "react-native-web": {
-            "version": "0.19.9",
-            "webpackConfig": {
-                "modulePaths": true
-            }
-        },
-        "react-native-tvos": {
-            "version": "0.73.1-3"
-        }
+        "react-native-gesture-handler": "source:rnv",
+        "@react-native-community/cli-platform-ios": "source:rnv",
+        "react-native": "source:rnv",
+        "next": "source:rnv",
+        "react-native-web": "source:rnv",
+        "react-native-tvos": "source:rnv"
     },
     "permissions": {
         "ios": {},

--- a/packages/template-starter/src/entry/index.web.ts
+++ b/packages/template-starter/src/entry/index.web.ts
@@ -1,5 +1,0 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from '../app';
-
-ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/packages/template-starter/src/entry/index.web.tsx
+++ b/packages/template-starter/src/entry/index.web.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from '../app';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
+);


### PR DESCRIPTION
## Description

Fixes:

- `rnv configure` would not trigger task but autocomplete of `configureSoft`
- cannot override template behavior like copy includedPaths assets every run
- prio tasks missing if running with single engine project
- improve logger color schema
- make logger display relative paths all the way to system root
- handle broken symlinks state
- avoid attempt to load all engines for global tasks which do not need it (ie rnv link)

How to test includedPaths (this test cannot be performed by scheme or command switch):

TEST 1:

1. 
```
cd app-harness
```
2. delete any of the files:

```
"tsconfig.json",
 "Gemfile",
  "metro.config.js",
   ".bundle",
    "react-native.config.js",
    "babel.config.js",
     "next.config.js",
      "next-env.d.ts",
     "webpack.config.js"
```

3. 

```
npx rnv configure -p ios
```

### Expected Result:
deleted files should be recreated

TEST 2:

run step 1,2

2. add following to `app-harness/renative.json`

```
"templateConfig": {
        "includedPaths": [
            "next.config.js",
        ]
}
```

3. 

```
npx rnv configure -p ios
```

### Expected Result:
only `next.config.js` should be recreated



## Related issues

- GH issues

## Npm releases

n/a
