### PR TITLE
add RNV_SKIP_LINKING env to androidRunner

### DIFF
--- a/packages/sdk-react-native/src/androidRunner.ts
+++ b/packages/sdk-react-native/src/androidRunner.ts
@@ -74,6 +74,7 @@ export const packageReactNativeAndroid = async (c: RnvContext) => {
                 ...CoreEnvVars.RNV_EXTENSIONS(),
                 ...EnvVars.RNV_REACT_NATIVE_PATH(),
                 ...EnvVars.RNV_APP_ID(),
+                ...EnvVars.RNV_SKIP_LINKING(),
             },
         });
 
@@ -112,6 +113,7 @@ export const runReactNativeAndroid = async (
             ...EnvVars.RCT_METRO_PORT(),
             ...EnvVars.RNV_REACT_NATIVE_PATH(),
             ...EnvVars.RNV_APP_ID(),
+            ...EnvVars.RNV_SKIP_LINKING(),
         },
         cwd: appFolder,
         //This is required to make rn cli logs visible in rnv executed terminal
@@ -144,6 +146,7 @@ export const buildReactNativeAndroid = async (c: RnvContext) => {
             ...CoreEnvVars.RNV_EXTENSIONS(),
             ...EnvVars.RNV_REACT_NATIVE_PATH(),
             ...EnvVars.RNV_APP_ID(),
+            ...EnvVars.RNV_SKIP_LINKING(),
         },
     });
 


### PR DESCRIPTION
## Description

- plugin disable doesn’t work for android platforms

## Related issues

- https://github.com/flexn-io/renative/issues/1467

## Npm releases

n/a
