### PR TITLE
fix/android_device_picking

### DIFF
--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -118,10 +118,6 @@ export const getAndroidDeviceToRunOn = async () => {
             if (activeDeviceInfoArr.length === 1 && inactiveDeviceInfoArr.length === 0 && !target) {
                 chosenTarget = activeDeviceInfoArr[0].value;
                 logInfo(`Found only one active target: ${chalk().magenta(chosenTarget)}. Will use it.`);
-            } else if (activeDeviceInfoArr.length === 0 && inactiveDeviceInfoArr.length === 1 && !target) {
-                //If we have no active devices and only one AVD available let's just launch it.
-                chosenTarget = inactiveDeviceInfoArr[0].value;
-                logInfo(`Found only one target to launch: ${chalk().magenta(chosenTarget)}. Will use it.`);
             } else {
                 const response = await inquirerPrompt({
                     name: 'chosenTarget',


### PR DESCRIPTION
## Description

- When user has only 1 sim, rnv forgets to ask for sim when it should and just launches that one sim

## Related issues

- https://github.com/flexn-io/renative/issues/1372

## Npm releases

n/a
