### PR TITLE
feat: infer payload type from extendModules

### DIFF
--- a/packages/core/src/engines/types.ts
+++ b/packages/core/src/engines/types.ts
@@ -6,12 +6,16 @@ import type { RnvPlatformKey } from '../types';
 
 export type RnvEnginePlatforms = Partial<Record<RnvPlatformKey, RnvEnginePlatform>>;
 
-export type CreateRnvEngineOpts<OKey extends string> = {
+type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
+
+type ExtractModulePayload<T extends RnvModule> = T extends RnvModule<any, infer Payload> ? Payload : never;
+
+export type CreateRnvEngineOpts<OKey extends string, Modules extends [RnvModule<OKey>, ...RnvModule<OKey>[]]> = {
     originalTemplatePlatformsDir?: string;
     platforms: RnvEnginePlatforms;
     config: ConfigFileEngine;
-    tasks: ReadonlyArray<RnvTask<OKey>>;
-    extendModules?: ReadonlyArray<RnvModule<OKey>>;
+    tasks: ReadonlyArray<RnvTask<OKey, UnionToIntersection<ExtractModulePayload<Modules[number]>>>>;
+    extendModules?: Modules;
     rootPath?: string;
     originalTemplatePlatformProjectDir?: string;
     projectDirName?: string;
@@ -20,7 +24,7 @@ export type CreateRnvEngineOpts<OKey extends string> = {
     serverDirName?: string;
 };
 
-export type RnvEngine<OKey extends string = string> = {
+export type RnvEngine<OKey extends string = string, Modules extends [RnvModule<OKey>, ...RnvModule<OKey>[]] = any> = {
     originalTemplatePlatformsDir?: string;
     platforms: RnvEnginePlatforms;
     id: string;
@@ -32,7 +36,7 @@ export type RnvEngine<OKey extends string = string> = {
     runtimeExtraProps: Record<string, string>;
     outputDirName?: string;
     serverDirName: string;
-    getContext: () => RnvContext<any, OKey>;
+    getContext: () => RnvContext<UnionToIntersection<ExtractModulePayload<Modules[number]>>, OKey>;
 };
 
 export type RnvEnginePlatform = {

--- a/packages/core/src/modules/creator.ts
+++ b/packages/core/src/modules/creator.ts
@@ -2,17 +2,19 @@ import { getContext } from '../context/provider';
 import { createTaskMap } from '../tasks/creators';
 import type { CreateRnvModuleOpts, RnvModule } from './types';
 
-export const createRnvModule = <OKey extends string>(opts: CreateRnvModuleOpts<OKey>) => {
+export const createRnvModule = <Payload extends object, OKey extends string = string>(
+    opts: CreateRnvModuleOpts<OKey>
+) => {
     if (!opts.name) {
         throw new Error('Module name is required!');
     }
 
-    const module: RnvModule<OKey> = {
+    const module: RnvModule<OKey, Payload> = {
         ...opts,
         originalTasks: opts.tasks,
         name: opts.name,
         tasks: createTaskMap<OKey>({ tasks: opts.tasks, ownerID: opts.name, ownerType: opts.type }),
-        getContext: () => getContext<any, OKey>(),
+        getContext,
     };
 
     return module;

--- a/packages/core/src/modules/types.ts
+++ b/packages/core/src/modules/types.ts
@@ -7,11 +7,11 @@ export type CreateRnvModuleOpts<OKey extends string> = {
     type: RnvModuleType;
 };
 
-export type RnvModule<OKey extends string = string> = {
+export type RnvModule<OKey extends string = string, Payload = any> = {
     name: string;
     tasks: RnvTaskMap<OKey>;
     originalTasks: ReadonlyArray<RnvTask<OKey>>;
-    getContext: () => RnvContext<any, OKey>;
+    getContext: () => RnvContext<Payload, OKey>;
 };
 
 export type RnvModuleType = 'engine' | 'public' | 'internal';

--- a/packages/core/src/tasks/types.ts
+++ b/packages/core/src/tasks/types.ts
@@ -18,7 +18,7 @@ export type CreateRnvTaskOpt<OKey extends string = string> = {
     ignoreEngines?: boolean;
 };
 
-export type RnvTask<OKey extends string = string> = {
+export type RnvTask<OKey extends string = string, Payload = any> = {
     task: string;
     dependsOn?: string[];
     options?: ReadonlyArray<RnvTaskOption<OKey>>;
@@ -27,7 +27,7 @@ export type RnvTask<OKey extends string = string> = {
     description: string;
     forceBuildHookRebuild?: boolean;
     beforeDependsOn?: RnvTaskFn;
-    fn?: RnvTaskFn<OKey>;
+    fn?: RnvTaskFn<OKey, Payload>;
     fnHelp?: RnvTaskHelpFn;
     isPrivate?: boolean;
     isPriorityOrder?: boolean;
@@ -69,8 +69,8 @@ export type RnvTaskOption<OKey extends string = string> = {
 export type RnvTaskMap<OKey extends string = string> = Record<string, RnvTask<OKey>>;
 
 //Too many choices of return types
-export type RnvTaskFn<OKey extends string = string> = (opts: {
-    ctx: RnvContext<any, OKey>;
+export type RnvTaskFn<OKey extends string = string, Payload = any> = (opts: {
+    ctx: RnvContext<Payload, OKey>;
     taskName: string;
     parentTaskName: string | undefined;
     originTaskName: string | undefined;

--- a/packages/sdk-android/src/index.ts
+++ b/packages/sdk-android/src/index.ts
@@ -12,8 +12,9 @@ import taskConfigure from './tasks/taskConfigure';
 import taskRun from './tasks/taskRun';
 import taskBuild from './tasks/taskBuild';
 import { GetContextType, createRnvModule } from '@rnv/core';
+import { Payload } from './types';
 
-const RnvModule = createRnvModule({
+const RnvModule = createRnvModule<Payload>({
     tasks: [
         taskTargetLaunch,
         taskTargetList,

--- a/packages/sdk-android/src/kotlinParser.ts
+++ b/packages/sdk-android/src/kotlinParser.ts
@@ -4,11 +4,11 @@ import {
     RnvContext,
     getAppFolder,
     getConfigProp,
-    getContext,
     writeCleanFile,
 } from '@rnv/core';
 import path from 'path';
 import { getBuildFilePath, getEntryFile, getAppId, addSystemInjects } from '@rnv/sdk-utils';
+import { getContext } from './getContext';
 
 // const JS_BUNDLE_DEFAULTS: Partial<Record<RnvPlatformKey, string>> = {
 //     // Android Wear does not support webview required for connecting to packager. this is hack to prevent RN connectiing to running bundler

--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -398,6 +398,7 @@ export const configureProject = async () => {
         buildGradleAfterAll: '',
         buildGradleBuildScriptDependencies: '',
         injectReactNativeEngine: '',
+        injectActivityOnCreate: '',
         buildGradleBuildScriptDexOptions: '',
         appBuildGradleSigningConfigs: '',
         packagingOptions: '',

--- a/packages/sdk-android/src/types.ts
+++ b/packages/sdk-android/src/types.ts
@@ -4,6 +4,7 @@ export type Payload = {
     pluginConfigAndroid: {
         gradleWrapperVersion: string;
         injectReactNativeEngine: string;
+        injectActivityOnCreate: string;
         appBuildGradleImplementations: string;
         pluginApplicationImports: string;
         reactNativeHostMethods: string;

--- a/packages/sdk-apple/src/index.ts
+++ b/packages/sdk-apple/src/index.ts
@@ -15,6 +15,7 @@ import taskConfigure from './tasks/taskConfigure';
 import taskRun from './tasks/taskRun';
 import taskBuild from './tasks/taskBuild';
 import { GetContextType, createRnvModule } from '@rnv/core';
+import { Payload } from './types';
 
 export const Tasks = [
     taskTargetLaunch,
@@ -31,7 +32,7 @@ export const Tasks = [
     taskBuild,
 ];
 
-const RnvModule = createRnvModule({
+const RnvModule = createRnvModule<Payload>({
     tasks: Tasks,
     name: '@rnv/sdk-apple',
     type: 'internal',

--- a/packages/sdk-apple/src/podfileParser.ts
+++ b/packages/sdk-apple/src/podfileParser.ts
@@ -9,10 +9,10 @@ import {
     parsePlugins,
     writeCleanFile,
     DEFAULTS,
-    getContext,
     type ConfigPluginPlatformSchema,
 } from '@rnv/core';
 import { addSystemInjects, getAppTemplateFolder } from '@rnv/sdk-utils';
+import { getContext } from './getContext';
 
 export const parsePodFile = async () => {
     logDefault('parsePodFile');


### PR DESCRIPTION
## Description

Updates the types so `Payload` is inferred from `extendModules`.


![extendModulesInfer](https://github.com/flexn-io/renative/assets/9592076/f4649128-077e-469d-9986-f131e4e51cc8)
