### PR TITLE
Fix: web font naming

### DIFF
--- a/packages/sdk-utils/templateFiles/fontManager.web.js
+++ b/packages/sdk-utils/templateFiles/fontManager.web.js
@@ -8,7 +8,7 @@ function registerFonts(fonts) {
 
 function registerFont(fontFamily, ttf) {
     if (ttf.default) ttf = ttf.default;
-    const fontStyles = `@font-face { src: url(${ttf}); font-family: ${fontFamily};}`;
+    const fontStyles = `@font-face { src: url(${ttf}); font-family: '${fontFamily}';}`;
     const id = `${fontFamily}FontFace`;
     if (!document.getElementById(id)) {
         const fStyle = document.createElement('style');


### PR DESCRIPTION
## Description

Web font-family always has to be string, if font starts with numeric then it's incorrectly registered