### PR TITLE
fix/macos_export

### DIFF
--- a/packages/engine-rn-electron/templates/platforms/macos/entitlements.mac.plist
+++ b/packages/engine-rn-electron/templates/platforms/macos/entitlements.mac.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.cs.allow-jit</key>
+    <true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>


### PR DESCRIPTION
## Description

- Set `com.apple.security.cs.allow-jit` entitlement for arm64 builds. This is required for Electron 20+
 https://www.electron.build/configuration/mac

## Related issues

- https://github.com/flexn-io/renative/issues/1533

## Npm releases

n/a
