### PR TITLE
Fix: RCTScrollViewTV doesn't exists

### DIFF
--- a/packages/config-templates/pluginTemplates/react-native-tvos/overrides.json
+++ b/packages/config-templates/pluginTemplates/react-native-tvos/overrides.json
@@ -1,8 +1,9 @@
 {
   "overrides": {
       "Libraries/Components/ScrollView/ScrollViewNativeComponent.js": {
-          "NativeComponentRegistry.get<Props>(\n    'RCTScrollView'": "NativeComponentRegistry.get<Props>(\n    Platform.isTV && Platform.OS === 'android' ? 'RCTScrollViewTV' : 'RCTScrollView'",
-          "Platform.OS === 'android'\n    ? {\n        uiViewClassName: 'RCTScrollView'": "Platform.OS === 'android'\n    ? {\n        uiViewClassName: Platform.isTV ? 'RCTScrollViewTV': 'RCTScrollView'"
+          "Platform';\n\nexport": "Platform';\nimport NativeModules from '../../BatchedBridge/NativeModules';\n\nexport",
+          "NativeComponentRegistry.get<Props>(\n    'RCTScrollView'": "NativeComponentRegistry.get<Props>(\n    Platform.isTV && 'RCTScrollViewTV' in NativeModules.UIManager && Platform.OS === 'android' ? 'RCTScrollViewTV' : 'RCTScrollView'",
+          "Platform.OS === 'android'\n    ? {\n        uiViewClassName: 'RCTScrollView'": "Platform.OS === 'android'\n    ? {\n        uiViewClassName: Platform.isTV && 'RCTScrollViewTV' in NativeModules.UIManager ? 'RCTScrollViewTV' : 'RCTScrollView'"
       }
   }
 }


### PR DESCRIPTION
## Description

Conditionally check if RCTScrollViewTV is a part of native components and only then apply override.

- Small description

## Related issues

https://github.com/flexn-io/renative/issues/1536

## Npm releases

n/a
