### PR TITLE
Fix(Windows:Runner): Fix web and android path to respective node modules not found

### DIFF
--- a/packages/engine-rn-next/src/sdk/runner.ts
+++ b/packages/engine-rn-next/src/sdk/runner.ts
@@ -104,7 +104,12 @@ export const buildWebNext = async () => {
     const c = getContext();
     logDefault('buildWebNext');
 
-    await executeAsync('npx next build', {
+
+    // On Windows npx does not always resolve correct path, hence we manually resolve it here
+    // https://github.com/flexn-io/renative/issues/1409#issuecomment-2095531486
+    const nextCmnd = `node ${path.join(path.dirname(require.resolve('next/package.json')), 'dist', 'bin', 'next')}`;
+    // const nextCmnd = 'npx next';
+    await executeAsync(`${nextCmnd} build`, {
         env: {
             ...CoreEnvVars.BASE(),
             ...CoreEnvVars.RNV_EXTENSIONS(),
@@ -130,7 +135,13 @@ Dev server running at: ${url}
     const opts = !c.program?.opts()?.json
         ? ExecOptionsPresets.INHERIT_OUTPUT_NO_SPINNER
         : ExecOptionsPresets.SPINNER_FULL_ERROR_SUMMARY;
-    return executeAsync(`npx next ${bundleAssets ? 'start' : 'dev'} --port ${c.runtime.port}`, {
+
+    // On Windows npx does not always resolve correct path, hence we manually resolve it here
+    // https://github.com/flexn-io/renative/issues/1409#issuecomment-2095531486
+    const nextCmnd = `node ${path.join(path.dirname(require.resolve('next/package.json')), 'dist', 'bin', 'next')}`;
+    // const nextCmnd = 'npx next';
+
+    return executeAsync(`${nextCmnd} ${bundleAssets ? 'start' : 'dev'} --port ${c.runtime.port}`, {
         env: {
             ...CoreEnvVars.BASE(),
             ...CoreEnvVars.RNV_EXTENSIONS(),
@@ -148,7 +159,12 @@ export const exportWebNext = async () => {
 
     const exportDir = getExportDir(c);
 
-    await executeAsync(`npx next build`, {
+    // On Windows npx does not always resolve correct path, hence we manually resolve it here
+    // https://github.com/flexn-io/renative/issues/1409#issuecomment-2095531486
+    const nextCmnd = `node ${path.join(path.dirname(require.resolve('next/package.json')), 'dist', 'bin', 'next')}`;
+    // const nextCmnd = 'npx next';
+
+    await executeAsync(`${nextCmnd} build`, {
         env: {
             ...CoreEnvVars.BASE(),
             ...CoreEnvVars.RNV_EXTENSIONS(),

--- a/packages/sdk-react-native/src/androidRunner.ts
+++ b/packages/sdk-react-native/src/androidRunner.ts
@@ -92,7 +92,7 @@ export const runReactNativeAndroid = async (device: { udid?: string } | undefine
     logDefault('_runGradleApp');
 
     const signingConfig = getConfigProp('signingConfig') || 'Debug';
-    const appFolder = c.paths.project.dir;
+    const appFolder = getAppFolder();
 
     const udid = device?.udid;
     // On Windows npx does not always resolve correct path, hence we manually resolve it here
@@ -129,8 +129,12 @@ export const buildReactNativeAndroid = async () => {
     const signingConfig = getConfigProp('signingConfig') || DEFAULTS.signingConfig;
     const outputAab = getConfigProp('aab');
     const extraGradleParams = getConfigProp('extraGradleParams') || '';
+    // On Windows npx does not always resolve correct path, hence we manually resolve it here
+    // https://github.com/flexn-io/renative/issues/1409#issuecomment-2095531486
+    const reactNativeCmnd = `node  ${path.join(path.dirname(require.resolve('react-native')), 'cli.js')}`;
+    // const reactNativeCmnd =  'npx react-native';
 
-    let command = `npx react-native build-android --mode=${signingConfig} --tasks ${outputAab ? 'bundle' : 'assemble'
+    let command = `${reactNativeCmnd} build-android --mode=${signingConfig} --tasks ${outputAab ? 'bundle' : 'assemble'
         }${signingConfig}`;
 
     if (extraGradleParams) {

--- a/packages/sdk-react-native/src/androidRunner.ts
+++ b/packages/sdk-react-native/src/androidRunner.ts
@@ -92,13 +92,16 @@ export const runReactNativeAndroid = async (device: { udid?: string } | undefine
     logDefault('_runGradleApp');
 
     const signingConfig = getConfigProp('signingConfig') || 'Debug';
-    const appFolder = getAppFolder();
+    const appFolder = c.paths.project.dir;
 
     const udid = device?.udid;
+    // On Windows npx does not always resolve correct path, hence we manually resolve it here
+    // https://github.com/flexn-io/renative/issues/1409#issuecomment-2095531486
+    const reactNativeCmnd = `node  ${path.join(path.dirname(require.resolve('react-native')), 'cli.js')}`;
+    // const reactNativeCmnd =  'npx react-native';
 
-    let command = `npx react-native run-android --mode=${signingConfig} --no-packager --main-activity=${
-        platform === 'androidwear' ? 'MainActivity' : 'SplashActivity'
-    }`;
+    let command = `${reactNativeCmnd} run-android --mode=${signingConfig} --no-packager --main-activity=${platform === 'androidwear' ? 'MainActivity' : 'SplashActivity'
+        }`;
 
     if (udid) {
         command += ` --deviceId=${udid}`;
@@ -127,9 +130,8 @@ export const buildReactNativeAndroid = async () => {
     const outputAab = getConfigProp('aab');
     const extraGradleParams = getConfigProp('extraGradleParams') || '';
 
-    let command = `npx react-native build-android --mode=${signingConfig} --tasks ${
-        outputAab ? 'bundle' : 'assemble'
-    }${signingConfig}`;
+    let command = `npx react-native build-android --mode=${signingConfig} --tasks ${outputAab ? 'bundle' : 'assemble'
+        }${signingConfig}`;
 
     if (extraGradleParams) {
         command += ` --extra-params ${extraGradleParams}`;

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -28,6 +28,7 @@
             "tvos",
             "webos",
             "macos",
+            "windows",
             "tizenwatch",
             "kaios",
             "chromecast",
@@ -100,7 +101,8 @@
             "assetFolderPlatform": "electron"
         },
         "windows": {
-            "engine": "engine-rn-electron"
+            "engine": "engine-rn-electron",
+            "assetFolderPlatform": "electron"
         },
         "ios": {
             "engine": "engine-rn",

--- a/packages/template-starter/renative.template.json
+++ b/packages/template-starter/renative.template.json
@@ -49,6 +49,7 @@
                     "webpack.config.js"
                 ],
                 "platforms": [
+                    "windows",
                     "macos",
                     "tizen",
                     "webos",


### PR DESCRIPTION
## Description

- Fix the issue when running web and android `app-harness` failed on Windows due to incorrect path picked up by npx to use for running commands. Example of such error can be seen in the linked comment on the issue.

## Related issues

- https://github.com/flexn-io/renative/issues/1409#issuecomment-2095531486
- https://github.com/flexn-io/renative/pull/1547 PR should be merged before this one as I noticed one more place that required updates for electron as well.

## Npm releases

n/a
