### PR TITLE
Fix missing dependency

### DIFF
--- a/packages/config-templates/renative.templates.json
+++ b/packages/config-templates/renative.templates.json
@@ -2340,6 +2340,9 @@
             "version": "5.3.1",
             "web": {}
         },
+        "dotenv": {
+            "version": "16.4.5"
+        },
         "react-native-gesture-handler": {
             "version": "2.14.1",
             "android": {

--- a/packages/sdk-android/src/__tests__/deviceManager.test.ts
+++ b/packages/sdk-android/src/__tests__/deviceManager.test.ts
@@ -138,7 +138,9 @@ describe('resetAdb', () => {
 describe('connectToWifiDevice', () => {
     it('fail when connect to faulty IP address', async () => {
         //GIVEN
-        jest.mocked(execCLI).mockResolvedValue("failed to connect to '1.1.1.1:5555': Operation timed out");
+        jest.mocked(execCLI).mockResolvedValue(
+            "Connection refused: failed to connect to '1.1.1.1:5555': Operation timed out"
+        );
         //WHEN
         const result = await deviceManager.connectToWifiDevice('1.1.1.1');
 

--- a/packages/template-starter/renative.template.json
+++ b/packages/template-starter/renative.template.json
@@ -49,7 +49,8 @@
                 "@rnv/adapter": "1.0.0-rc.18",
                 "@rnv/config-templates": "1.0.0-rc.18",
                 "babel-loader": "9.1.3",
-                "readable-stream": "4.5.2"
+                "readable-stream": "4.5.2",
+                "dotenv": "16.4.5"
             },
             "browserslist": {
                 "production": [">0.2%", "not dead", "not op_mini all"],


### PR DESCRIPTION
## Description

- Bug: Platform is not running because it missing `dotenv` dependency.
- Platforms: `android`, `ios`

- Add `dotenv` dependency for android platform in new project. 

## Related issues

n/a

## Npm releases

n/a
