### PR TITLE
fix(iOS:DefaultSim): Fix simulator prompt not shown when none defined

### DIFF
--- a/packages/sdk-apple/src/__tests__/runner.test.ts
+++ b/packages/sdk-apple/src/__tests__/runner.test.ts
@@ -85,6 +85,15 @@ describe('getIosDeviceToRunOn', () => {
             }
 
             if (type === 'list') {
+                // Testing the addition of global/project value should be handled in another UT
+                if (choices?.includes("Don't update")) {
+                    const choiceIndex = choices.findIndex((c) => c === "Don't update");
+                    return {
+                        [name as string]:
+                            (choices![choiceIndex] as { name: string; value: any }).value || choices![choiceIndex],
+                    };
+                }
+                // By default first value returned (aka the first simulator from the list in this case)
                 return {
                     [name as string]: (choices![0] as { name: string; value: any }).value || choices![0],
                 };
@@ -94,10 +103,7 @@ describe('getIosDeviceToRunOn', () => {
         const deviceArgs = await getIosDeviceToRunOn(ctx);
         //THEN
         expect(getAppleDevices).toHaveBeenCalledTimes(1);
-        // TODO: check the expected logic here because getIosDeviceToRunOn
-        // returns undefined in case of no target
-        expect(deviceArgs).toBe(undefined);
-        // expect(deviceArgs).toBe('--simulator iPhone\\ SE\\ (3rd\\ generation)');
+        expect(deviceArgs).toBe('--simulator iPhone\\ SE\\ (3rd\\ generation)');
     });
 
     it('should return the correct device when specified', async () => {

--- a/packages/sdk-apple/src/runner.ts
+++ b/packages/sdk-apple/src/runner.ts
@@ -146,14 +146,16 @@ export const getIosDeviceToRunOn = async (c: Context) => {
         if (c.runtime.target) {
             p = `--simulator ${c.runtime.target.replace(/(\s+)/g, '\\$1')}`;
         }
-    } else if (c.runtime.target) {
+    } else {
         // check if the default sim is available
         const desiredSim = devicesArr.find((d) => d.name === c.runtime.target && !d.isDevice);
 
         if (!desiredSim) {
             const { sim } = await inquirerPrompt({
                 name: 'sim',
-                message: `We couldn't find ${c.runtime.target} as a simulator supported by the current version of your Xcode. Please select another sim`,
+                message: !c.runtime.target
+                    ? `No global or project default simulator defined. Please select a supported simulator to use`
+                    : `We couldn't find ${c.runtime.target} as a simulator supported by the current version of your Xcode. Please select another sim`,
                 type: 'list',
                 choices: devicesArr
                     .filter((d) => !d.isDevice)

--- a/packages/sdk-apple/src/runner.ts
+++ b/packages/sdk-apple/src/runner.ts
@@ -146,7 +146,7 @@ export const getIosDeviceToRunOn = async (c: Context) => {
         if (c.runtime.target) {
             p = `--simulator ${c.runtime.target.replace(/(\s+)/g, '\\$1')}`;
         }
-    } else {
+    } else if (c.runtime.target || devicesArr.length > 0) {
         // check if the default sim is available
         const desiredSim = devicesArr.find((d) => d.name === c.runtime.target && !d.isDevice);
 


### PR DESCRIPTION
## Description

- Fix the simulator selection prompt not appearing when there is no project or global default simulator provided. New prompt text should look like this with the abilities to select a simulator for one time run, add it in the project or global defaults.

![Screenshot 2024-05-23 at 15 07 19](https://github.com/flexn-io/renative/assets/36963057/3381f958-480c-487e-a8eb-53cf5873afba)


## Related issues

- https://github.com/flexn-io/renative/issues/1569

## Npm releases

n/a
