### PR TITLE
Fix kaios target list

### DIFF
--- a/packages/engine-rn-web/src/index.ts
+++ b/packages/engine-rn-web/src/index.ts
@@ -1,6 +1,7 @@
 import { createRnvEngine, GetContextType } from '@rnv/core';
 import ModuleSDKWebOS from '@rnv/sdk-webos';
 import ModuleSDKTizen from '@rnv/sdk-tizen';
+import ModuleSDKKaios from '@rnv/sdk-kaios';
 import { withRNVBabel, withRNVWebpack } from './adapter';
 import taskRun from './tasks/taskRun';
 import taskBuild from './tasks/taskBuild';
@@ -10,7 +11,7 @@ import taskDebug from './tasks/taskDebug';
 import { Config } from './config';
 
 const Engine = createRnvEngine({
-    extendModules: [ModuleSDKWebOS, ModuleSDKTizen],
+    extendModules: [ModuleSDKWebOS, ModuleSDKTizen, ModuleSDKKaios],
     tasks: [taskRun, taskBuild, taskConfigure, taskStart, taskDebug] as const,
     config: Config,
     platforms: {

--- a/packages/sdk-kaios/src/deviceManager.ts
+++ b/packages/sdk-kaios/src/deviceManager.ts
@@ -7,6 +7,7 @@ import {
     getContext,
     executeAsync,
     ExecOptionsPresets,
+    logToSummary,
 } from '@rnv/core';
 import path from 'path';
 
@@ -44,4 +45,26 @@ export const launchKaiOSSimulator = async (target: string | boolean) => {
         cwd: `${kaiosSdkPath}/${target}/kaiosrt`,
         ...ExecOptionsPresets.NO_SPINNER_FULL_ERROR_SUMMARY,
     });
+};
+
+export const listKaiosTargets = async () => {
+    const c = getContext();
+
+    const kaiosSdkPath = getRealPath(c.buildConfig?.sdks?.KAIOS_SDK);
+
+    if (!kaiosSdkPath) {
+        return Promise.reject(`c.buildConfig.sdks.KAIOS_SDK undefined`);
+    }
+
+    const availableSimulatorVersions = getDirectories(kaiosSdkPath).filter(
+        (directory) => directory.toLowerCase().indexOf('kaios') !== -1
+    );
+
+    // availableSimulatorVersions.map((a) => {
+    //     deviceArray.push(` [${deviceArray.length + 1}]> ${chalk().bold(a)} | simulator`);
+    // });
+
+    logToSummary(`Kaios Targets:\n${availableSimulatorVersions.join('\n')}`);
+
+    return true;
 };

--- a/packages/sdk-kaios/src/index.ts
+++ b/packages/sdk-kaios/src/index.ts
@@ -4,9 +4,10 @@ export * from './constants';
 
 import { GetContextType, createRnvModule } from '@rnv/core';
 import taskTargetLaunch from './tasks/taskTargetLaunch';
+import taskTargetList from './tasks/taskTargetList';
 
 const RnvModule = createRnvModule({
-    tasks: [taskTargetLaunch] as const,
+    tasks: [taskTargetLaunch, taskTargetList] as const,
     name: '@rnv/sdk-kaios',
     type: 'internal',
 });

--- a/packages/sdk-kaios/src/tasks/taskTargetList.ts
+++ b/packages/sdk-kaios/src/tasks/taskTargetList.ts
@@ -1,0 +1,15 @@
+import { createTask, RnvTaskName, RnvTaskOptions } from '@rnv/core';
+import { listKaiosTargets } from '../deviceManager';
+import { SdkPlatforms } from '../constants';
+
+export default createTask({
+    description: 'List all available targets for specific platform',
+    dependsOn: [RnvTaskName.workspaceConfigure],
+    fn: async () => {
+        return listKaiosTargets();
+    },
+    task: RnvTaskName.targetList,
+    options: [RnvTaskOptions.target],
+    platforms: SdkPlatforms,
+    isGlobalScope: true,
+});


### PR DESCRIPTION
## Description

- Fix command so that list of supported simulators is shown or target launches

## Related issues

- https://github.com/flexn-io/renative/issues/1583

## Npm releases

n/a
