### PR TITLE
Add error msg in webos

### DIFF
--- a/packages/sdk-webos/src/deviceManager.ts
+++ b/packages/sdk-webos/src/deviceManager.ts
@@ -43,6 +43,9 @@ export const launchWebOSimulator = async (target: string | boolean) => {
     const availableSimulatorVersions = getDirectories(path.join(webosSdkPath, 'Simulator'));
 
     if (target === true) {
+        if(availableSimulatorVersions.length == 0){
+            return Promise.reject(`Simulators not found in the specified path: ${path.join(webosSdkPath, 'Simulator')}`);
+        }
         const { selectedSimulator } = await inquirerPrompt({
             name: 'selectedSimulator',
             type: 'list',
@@ -67,9 +70,13 @@ export const launchWebOSimulator = async (target: string | boolean) => {
     );
 
     if (c.isSystemWin || c.isSystemLinux) {
+        try {
         await executeAsync(ePath, ExecOptionsPresets.SPINNER_FULL_ERROR_SUMMARY);
         logSuccess(`successfully launched ${target}`);
         return true;
+        } catch (error) {
+            return Promise.reject(`The Simulator can't be launched because it is already in use.`);
+        }
     }
 
     await executeAsync(`${openCommand} ${ePath}`, ExecOptionsPresets.FIRE_AND_FORGET);

--- a/packages/sdk-webos/src/deviceManager.ts
+++ b/packages/sdk-webos/src/deviceManager.ts
@@ -43,8 +43,10 @@ export const launchWebOSimulator = async (target: string | boolean) => {
     const availableSimulatorVersions = getDirectories(path.join(webosSdkPath, 'Simulator'));
 
     if (target === true) {
-        if(availableSimulatorVersions.length == 0){
-            return Promise.reject(`Simulators not found in the specified path: ${path.join(webosSdkPath, 'Simulator')}`);
+        if (availableSimulatorVersions.length === 0) {
+            return Promise.reject(
+                `Simulators not found in the specified path: ${path.join(webosSdkPath, 'Simulator')}`
+            );
         }
         const { selectedSimulator } = await inquirerPrompt({
             name: 'selectedSimulator',
@@ -71,9 +73,9 @@ export const launchWebOSimulator = async (target: string | boolean) => {
 
     if (c.isSystemWin || c.isSystemLinux) {
         try {
-        await executeAsync(ePath, ExecOptionsPresets.SPINNER_FULL_ERROR_SUMMARY);
-        logSuccess(`successfully launched ${target}`);
-        return true;
+            await executeAsync(ePath, ExecOptionsPresets.SPINNER_FULL_ERROR_SUMMARY);
+            logSuccess(`successfully launched ${target}`);
+            return true;
         } catch (error) {
             return Promise.reject(`The Simulator can't be launched because it is already in use.`);
         }


### PR DESCRIPTION
## Description

- Added webos error messages when: 
- there are no simulators 
- in windows trying to run sim second time

## Related issues

n/a

## Npm releases

n/a
