### PR TITLE
fix(Windows:Link): Initial fix that passes the link phase

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,8 +45,7 @@
         "svg2js": "0.0.4-alpha1",
         "tslib": "2.5.2",
         "type-fest": "4.14.0",
-        "zod": "3.22.4",
-        "graceful-fs": "^4.2.11"
+        "zod": "3.22.4"
     },
     "peerDependencies": {
         "@rnv/config-templates": "^1.0.0-rc.19"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,8 @@
         "svg2js": "0.0.4-alpha1",
         "tslib": "2.5.2",
         "type-fest": "4.14.0",
-        "zod": "3.22.4"
+        "zod": "3.22.4",
+        "graceful-fs": "^4.2.11"
     },
     "peerDependencies": {
         "@rnv/config-templates": "^1.0.0-rc.19"

--- a/packages/core/src/system/fs.ts
+++ b/packages/core/src/system/fs.ts
@@ -40,8 +40,6 @@ export const fsChmodSync = (dest: fs.PathLike | undefined, flag: fs.Mode) => fs.
 export const fsRenameSync = (arg1: fs.PathLike | undefined, arg2: fs.PathLike) => {
     // One of the paths does not exist
     if (!arg1 || !arg2) return;
-    // File already exists with renamed name, skip renaming
-    if (fs.existsSync(arg2)) return;
 
     if (fs.lstatSync(arg1).isDirectory()) {
         fs.cpSync(arg1 as string, arg2 as string, { recursive: true });

--- a/packages/core/src/system/fs.ts
+++ b/packages/core/src/system/fs.ts
@@ -1,4 +1,4 @@
-import fs from 'graceful-fs';
+import fs from 'fs';
 import path from 'path';
 import rimraf from 'rimraf';
 import Svg2Js from 'svg2js';

--- a/packages/core/src/system/fs.ts
+++ b/packages/core/src/system/fs.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'graceful-fs';
 import path from 'path';
 import rimraf from 'rimraf';
 import Svg2Js from 'svg2js';
@@ -37,7 +37,19 @@ export const fsReadFileSync = (dest: fs.PathLike | undefined) => fs.readFileSync
 
 export const fsChmodSync = (dest: fs.PathLike | undefined, flag: fs.Mode) => fs.chmodSync(dest!, flag);
 
-export const fsRenameSync = (arg1: fs.PathLike | undefined, arg2: fs.PathLike) => fs.renameSync(arg1!, arg2);
+export const fsRenameSync = (arg1: fs.PathLike | undefined, arg2: fs.PathLike) => {
+    // One of the paths does not exist
+    if (!arg1 || !arg2) return;
+    // File already exists with renamed name, skip renaming
+    if (fs.existsSync(arg2)) return;
+
+    if (fs.lstatSync(arg1).isDirectory()) {
+        fs.cpSync(arg1 as string, arg2 as string, { recursive: true });
+        fs.rmdirSync(arg1, { recursive: true });
+    } else if (fs.lstatSync(arg1).isFile()) {
+        fs.renameSync(arg1, arg2);
+    }
+};
 
 export const fsStatSync = (arg1: fs.PathLike | undefined) => fs.statSync(arg1!);
 

--- a/packages/core/src/system/fs.ts
+++ b/packages/core/src/system/fs.ts
@@ -39,14 +39,16 @@ export const fsChmodSync = (dest: fs.PathLike | undefined, flag: fs.Mode) => fs.
 
 export const fsRenameSync = (arg1: fs.PathLike | undefined, arg2: fs.PathLike) => {
     // One of the paths does not exist
-    if (!arg1 || !arg2) return;
+    if (!arg1 || !arg2) return logError(`Cannot rename file. source path doesn't exist: ${!arg1 ? arg1 : arg2}`);
 
+    // If it's a directory, on Windows all files within need to be copied over, simple renaming
+    // will cause a permitions error
     if (fs.lstatSync(arg1).isDirectory()) {
         fs.cpSync(arg1 as string, arg2 as string, { recursive: true });
         fs.rmdirSync(arg1, { recursive: true });
-    } else if (fs.lstatSync(arg1).isFile()) {
-        fs.renameSync(arg1, arg2);
+        return;
     }
+    return fs.renameSync(arg1, arg2);
 };
 
 export const fsStatSync = (arg1: fs.PathLike | undefined) => fs.statSync(arg1!);

--- a/packages/core/src/system/fs.ts
+++ b/packages/core/src/system/fs.ts
@@ -43,7 +43,12 @@ export const fsRenameSync = (arg1: fs.PathLike | undefined, arg2: fs.PathLike) =
     // File already exists with renamed name, skip renaming
     if (fs.existsSync(arg2)) return;
 
-    fs.renameSync(arg1, arg2);
+    if (fs.lstatSync(arg1).isDirectory()) {
+        fs.cpSync(arg1 as string, arg2 as string, { recursive: true });
+        fs.rmdirSync(arg1, { recursive: true });
+    } else if (fs.lstatSync(arg1).isFile()) {
+        fs.renameSync(arg1, arg2);
+    }
 };
 
 export const fsStatSync = (arg1: fs.PathLike | undefined) => fs.statSync(arg1!);

--- a/packages/core/src/system/fs.ts
+++ b/packages/core/src/system/fs.ts
@@ -43,12 +43,7 @@ export const fsRenameSync = (arg1: fs.PathLike | undefined, arg2: fs.PathLike) =
     // File already exists with renamed name, skip renaming
     if (fs.existsSync(arg2)) return;
 
-    if (fs.lstatSync(arg1).isDirectory()) {
-        fs.cpSync(arg1 as string, arg2 as string, { recursive: true });
-        fs.rmdirSync(arg1, { recursive: true });
-    } else if (fs.lstatSync(arg1).isFile()) {
-        fs.renameSync(arg1, arg2);
-    }
+    fs.renameSync(arg1, arg2);
 };
 
 export const fsStatSync = (arg1: fs.PathLike | undefined) => fs.statSync(arg1!);

--- a/packages/engine-core/src/tasks/linking/taskLink.ts
+++ b/packages/engine-core/src/tasks/linking/taskLink.ts
@@ -28,7 +28,7 @@ const _linkPackage = (pkg: LinkablePackage) => {
         logInfo(`${pkg.name} is set to skip linking. SKIPPING`);
     } else if (pkg.nmPathExists) {
         if (pkg.unlinkedPathExists) {
-            logInfo(`${pkg.name} found in exisitng cache. Removing and relinking...`);
+            logInfo(`${pkg.name} found in existing cache. Removing and relinking...`);
             removeDirSync(pkg.unlinkedPath);
         }
         mkdirSync(pkg.unlinkedPath);


### PR DESCRIPTION
## Description

- Updated rename function as on Windows it required moving files, simple renaming was not enough.

## Related issues

- https://github.com/flexn-io/renative/issues/1596

## Npm releases

n/a

## Screenshots

![image](https://github.com/flexn-io/renative/assets/36963057/15f0ddfd-1a52-4327-95e9-932676afe573)

