### PR TITLE
fixed duplication of the 'app configure' task when using -c option

### DIFF
--- a/packages/engine-core/src/tasks/app/taskAppConfigure.ts
+++ b/packages/engine-core/src/tasks/app/taskAppConfigure.ts
@@ -206,6 +206,7 @@ const appConfigure = async () => {
 export default createTask({
     description: 'Configure project with specific appConfig',
     fn: async ({ ctx }) => {
+        if (ctx.runtime.isAppConfigured) return true;
         await appConfigure();
         await updateRenativeConfigs();
         logAppInfo(ctx);


### PR DESCRIPTION
## Description

- User needs to choose config twice when using -c option

## Related issues

- https://github.com/flexn-io/renative/issues/1616

## Npm releases

n/a
