### PR TITLE
Refactor webpack excluded dirs

### DIFF
--- a/packages/adapter/src/adapters.ts
+++ b/packages/adapter/src/adapters.ts
@@ -1,10 +1,12 @@
 import fs from 'fs';
 import type { BabelApi, BabelConfig, BabelConfigPlugin } from './types';
 
+const env = process?.env;
+
 export const withBabelPluginModuleResolver = (cnf?: any): BabelConfigPlugin => [
     require.resolve('babel-plugin-module-resolver'),
     {
-        root: [process.env.RNV_MONO_ROOT || '.'],
+        root: [env.RNV_MONO_ROOT || '.'],
         ...(cnf || {}),
     },
 ];
@@ -20,14 +22,14 @@ export const withRNVBabel =
     (cnf: BabelConfig) =>
     (api: BabelApi): BabelConfig => {
         api.cache(true);
-        if (process.env.RNV_ENGINE_PATH && !fs.existsSync(process.env.RNV_ENGINE_PATH)) {
-            console.warn(`Path to engine cannot be resolved: ${process.env.RNV_ENGINE_PATH}. Will use default one`);
+        if (env.RNV_ENGINE_PATH && !fs.existsSync(env.RNV_ENGINE_PATH)) {
+            console.warn(`Path to engine cannot be resolved: ${env.RNV_ENGINE_PATH}. Will use default one`);
             api.cache(false);
             return _withDefaultRNVBabel(cnf);
         }
 
-        if (process.env.RNV_ENGINE_PATH) {
-            const engine = require(process.env.RNV_ENGINE_PATH);
+        if (env.RNV_ENGINE_PATH) {
+            const engine = require(env.RNV_ENGINE_PATH);
             api.cache(true);
             if (engine.withRNVBabel) {
                 return engine.withRNVBabel(cnf);
@@ -38,8 +40,8 @@ export const withRNVBabel =
     };
 
 export const withRNVMetro = (cnf: unknown) => {
-    if (process.env.RNV_ENGINE_PATH) {
-        const engine = require(process.env.RNV_ENGINE_PATH);
+    if (env.RNV_ENGINE_PATH) {
+        const engine = require(env.RNV_ENGINE_PATH);
         if (engine.withRNVMetro) {
             return engine.withRNVMetro(cnf);
         }
@@ -49,8 +51,8 @@ export const withRNVMetro = (cnf: unknown) => {
 };
 
 export const withRNVRNConfig = (cnf: unknown) => {
-    if (process.env.RNV_ENGINE_PATH) {
-        const engine = require(process.env.RNV_ENGINE_PATH);
+    if (env.RNV_ENGINE_PATH) {
+        const engine = require(env.RNV_ENGINE_PATH);
         if (engine.withRNVRNConfig) {
             return engine.withRNVRNConfig(cnf);
         }
@@ -60,8 +62,8 @@ export const withRNVRNConfig = (cnf: unknown) => {
 };
 
 export const withRNVNext = (cnf: unknown) => {
-    if (process.env.RNV_ENGINE_PATH) {
-        const engine = require(process.env.RNV_ENGINE_PATH);
+    if (env.RNV_ENGINE_PATH) {
+        const engine = require(env.RNV_ENGINE_PATH);
         if (engine.withRNVNext) {
             return engine.withRNVNext(cnf);
         }
@@ -71,8 +73,8 @@ export const withRNVNext = (cnf: unknown) => {
 };
 
 export const withRNVWebpack = (cnf: unknown) => {
-    if (process.env.RNV_ENGINE_PATH) {
-        const engine = require(process.env.RNV_ENGINE_PATH);
+    if (env.RNV_ENGINE_PATH) {
+        const engine = require(env.RNV_ENGINE_PATH);
         if (engine.withRNVWebpack) {
             return engine.withRNVWebpack(cnf);
         }

--- a/packages/core/jsonSchema/renative-1.0.schema.json
+++ b/packages/core/jsonSchema/renative-1.0.schema.json
@@ -480,13 +480,6 @@
               },
               "getJsBundleFile": {
                 "type": "string"
-              },
-              "webpackExcludedDirs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code. By default, the \"pages\" folder is excluded for web platforms that do not use next.js."
               }
             },
             "additionalProperties": false
@@ -1603,9 +1596,6 @@
                   "getJsBundleFile": {
                     "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                   },
-                  "webpackExcludedDirs": {
-                    "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                  },
                   "enableAndroidX": {
                     "type": [
                       "boolean",
@@ -1853,9 +1843,6 @@
             "getJsBundleFile": {
               "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
             },
-            "webpackExcludedDirs": {
-              "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-            },
             "enableAndroidX": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/android/properties/buildSchemes/additionalProperties/properties/enableAndroidX",
               "description": "Enables new android X architecture"
@@ -2067,9 +2054,6 @@
                   },
                   "getJsBundleFile": {
                     "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                  },
-                  "webpackExcludedDirs": {
-                    "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                   },
                   "ignoreWarnings": {
                     "type": "boolean",
@@ -2409,9 +2393,6 @@
             "getJsBundleFile": {
               "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
             },
-            "webpackExcludedDirs": {
-              "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-            },
             "ignoreWarnings": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings",
               "description": "Injects `inhibit_all_warnings` into Podfile"
@@ -2617,9 +2598,6 @@
                   "getJsBundleFile": {
                     "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                   },
-                  "webpackExcludedDirs": {
-                    "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                  },
                   "package": {
                     "type": "string"
                   },
@@ -2653,6 +2631,13 @@
                           "type": "string"
                         },
                         "description": "Allows you to inject custom script into html header"
+                      },
+                      "excludedDirs": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code."
                       }
                     },
                     "additionalProperties": false
@@ -2774,9 +2759,6 @@
             },
             "getJsBundleFile": {
               "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-            },
-            "webpackExcludedDirs": {
-              "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
             },
             "package": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/tizen/properties/buildSchemes/additionalProperties/properties/package"
@@ -2905,9 +2887,6 @@
                   },
                   "getJsBundleFile": {
                     "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                  },
-                  "webpackExcludedDirs": {
-                    "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                   },
                   "iconColor": {
                     "type": "string"
@@ -3042,9 +3021,6 @@
             "getJsBundleFile": {
               "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
             },
-            "webpackExcludedDirs": {
-              "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-            },
             "iconColor": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/webos/properties/buildSchemes/additionalProperties/properties/iconColor"
             },
@@ -3160,9 +3136,6 @@
                   },
                   "getJsBundleFile": {
                     "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                  },
-                  "webpackExcludedDirs": {
-                    "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                   },
                   "webpackConfig": {
                     "$ref": "#/definitions/zodPlatformsSchema/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
@@ -3312,9 +3285,6 @@
             "getJsBundleFile": {
               "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
             },
-            "webpackExcludedDirs": {
-              "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-            },
             "webpackConfig": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
             },
@@ -3452,9 +3422,6 @@
                   "getJsBundleFile": {
                     "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                   },
-                  "webpackExcludedDirs": {
-                    "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                  },
                   "ignoreWarnings": {
                     "$ref": "#/definitions/zodPlatformsSchema/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings"
                   },
@@ -3573,6 +3540,9 @@
                     },
                     "additionalProperties": false,
                     "description": "Allows you to configure electron wrapper app window"
+                  },
+                  "webpackConfig": {
+                    "$ref": "#/definitions/zodPlatformsSchema/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                   }
                 },
                 "additionalProperties": false
@@ -3692,9 +3662,6 @@
             "getJsBundleFile": {
               "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
             },
-            "webpackExcludedDirs": {
-              "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-            },
             "ignoreWarnings": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings",
               "description": "Injects `inhibit_all_warnings` into Podfile"
@@ -3803,6 +3770,9 @@
             "BrowserWindow": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/macos/properties/buildSchemes/additionalProperties/properties/BrowserWindow",
               "description": "Allows you to configure electron wrapper app window"
+            },
+            "webpackConfig": {
+              "$ref": "#/definitions/zodPlatformsSchema/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
             }
           },
           "additionalProperties": false
@@ -3907,9 +3877,6 @@
                   },
                   "getJsBundleFile": {
                     "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                  },
-                  "webpackExcludedDirs": {
-                    "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                   },
                   "electronConfig": {
                     "$ref": "#/definitions/zodPlatformsSchema/properties/macos/properties/buildSchemes/additionalProperties/properties/electronConfig"
@@ -4039,6 +4006,9 @@
                       }
                     },
                     "additionalProperties": false
+                  },
+                  "webpackConfig": {
+                    "$ref": "#/definitions/zodPlatformsSchema/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                   }
                 },
                 "additionalProperties": false
@@ -4158,9 +4128,6 @@
             "getJsBundleFile": {
               "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
             },
-            "webpackExcludedDirs": {
-              "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-            },
             "electronConfig": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/macos/properties/buildSchemes/additionalProperties/properties/electronConfig",
               "description": "Allows you to configure electron app as per https://www.electron.build/"
@@ -4175,6 +4142,9 @@
             },
             "templateVSProject": {
               "$ref": "#/definitions/zodPlatformsSchema/properties/windows/properties/buildSchemes/additionalProperties/properties/templateVSProject"
+            },
+            "webpackConfig": {
+              "$ref": "#/definitions/zodPlatformsSchema/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
             }
           },
           "additionalProperties": false
@@ -4380,9 +4350,6 @@
         },
         "getJsBundleFile": {
           "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-        },
-        "webpackExcludedDirs": {
-          "$ref": "#/definitions/zodCommonSchema/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
         }
       },
       "additionalProperties": false
@@ -5310,13 +5277,6 @@
                   "xbox"
                 ]
               }
-            },
-            "webpackExcludedDirs": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code."
             }
           },
           "additionalProperties": false

--- a/packages/core/jsonSchema/rnv.app.json
+++ b/packages/core/jsonSchema/rnv.app.json
@@ -260,13 +260,6 @@
                   },
                   "getJsBundleFile": {
                     "type": "string"
-                  },
-                  "webpackExcludedDirs": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code. By default, the \"pages\" folder is excluded for web platforms that do not use next.js."
                   }
                 },
                 "additionalProperties": false
@@ -376,9 +369,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "enableAndroidX": {
                         "type": [
@@ -1024,9 +1014,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "enableAndroidX": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/android/properties/buildSchemes/additionalProperties/properties/enableAndroidX",
                   "description": "Enables new android X architecture"
@@ -1238,9 +1225,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "ignoreWarnings": {
                         "type": "boolean",
@@ -1825,9 +1809,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "ignoreWarnings": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings",
                   "description": "Injects `inhibit_all_warnings` into Podfile"
@@ -2033,9 +2014,6 @@
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                       },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                      },
                       "package": {
                         "type": "string"
                       },
@@ -2069,6 +2047,13 @@
                               "type": "string"
                             },
                             "description": "Allows you to inject custom script into html header"
+                          },
+                          "excludedDirs": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code."
                           }
                         },
                         "additionalProperties": false
@@ -2190,9 +2175,6 @@
                 },
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                 },
                 "package": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/package"
@@ -2321,9 +2303,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "iconColor": {
                         "type": "string"
@@ -2458,9 +2437,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "iconColor": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/webos/properties/buildSchemes/additionalProperties/properties/iconColor"
                 },
@@ -2576,9 +2552,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "webpackConfig": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
@@ -2728,9 +2701,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "webpackConfig": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                 },
@@ -2868,9 +2838,6 @@
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                       },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                      },
                       "ignoreWarnings": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings"
                       },
@@ -2989,6 +2956,9 @@
                         },
                         "additionalProperties": false,
                         "description": "Allows you to configure electron wrapper app window"
+                      },
+                      "webpackConfig": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                       }
                     },
                     "additionalProperties": false
@@ -3108,9 +3078,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "ignoreWarnings": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings",
                   "description": "Injects `inhibit_all_warnings` into Podfile"
@@ -3219,6 +3186,9 @@
                 "BrowserWindow": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/macos/properties/buildSchemes/additionalProperties/properties/BrowserWindow",
                   "description": "Allows you to configure electron wrapper app window"
+                },
+                "webpackConfig": {
+                  "$ref": "#/definitions/rnv.app/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                 }
               },
               "additionalProperties": false
@@ -3323,9 +3293,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "electronConfig": {
                         "$ref": "#/definitions/rnv.app/properties/platforms/properties/macos/properties/buildSchemes/additionalProperties/properties/electronConfig"
@@ -3455,6 +3422,9 @@
                           }
                         },
                         "additionalProperties": false
+                      },
+                      "webpackConfig": {
+                        "$ref": "#/definitions/rnv.app/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                       }
                     },
                     "additionalProperties": false
@@ -3574,9 +3544,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.app/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "electronConfig": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/macos/properties/buildSchemes/additionalProperties/properties/electronConfig",
                   "description": "Allows you to configure electron app as per https://www.electron.build/"
@@ -3591,6 +3558,9 @@
                 },
                 "templateVSProject": {
                   "$ref": "#/definitions/rnv.app/properties/platforms/properties/windows/properties/buildSchemes/additionalProperties/properties/templateVSProject"
+                },
+                "webpackConfig": {
+                  "$ref": "#/definitions/rnv.app/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                 }
               },
               "additionalProperties": false

--- a/packages/core/jsonSchema/rnv.engine.json
+++ b/packages/core/jsonSchema/rnv.engine.json
@@ -85,13 +85,6 @@
             ]
           }
         },
-        "webpackExcludedDirs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code."
-        },
         "$schema": {
           "type": "string",
           "description": "schema definition"

--- a/packages/core/jsonSchema/rnv.project.json
+++ b/packages/core/jsonSchema/rnv.project.json
@@ -605,13 +605,6 @@
                   },
                   "getJsBundleFile": {
                     "type": "string"
-                  },
-                  "webpackExcludedDirs": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code. By default, the \"pages\" folder is excluded for web platforms that do not use next.js."
                   }
                 },
                 "additionalProperties": false
@@ -721,9 +714,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "enableAndroidX": {
                         "type": [
@@ -1369,9 +1359,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "enableAndroidX": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/android/properties/buildSchemes/additionalProperties/properties/enableAndroidX",
                   "description": "Enables new android X architecture"
@@ -1583,9 +1570,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "ignoreWarnings": {
                         "type": "boolean",
@@ -2170,9 +2154,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "ignoreWarnings": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings",
                   "description": "Injects `inhibit_all_warnings` into Podfile"
@@ -2378,9 +2359,6 @@
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                       },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                      },
                       "package": {
                         "type": "string"
                       },
@@ -2414,6 +2392,13 @@
                               "type": "string"
                             },
                             "description": "Allows you to inject custom script into html header"
+                          },
+                          "excludedDirs": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Allows to specify files or directories in the src folder that webpack should ignore when bundling code."
                           }
                         },
                         "additionalProperties": false
@@ -2535,9 +2520,6 @@
                 },
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                 },
                 "package": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/package"
@@ -2666,9 +2648,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "iconColor": {
                         "type": "string"
@@ -2803,9 +2782,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "iconColor": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/webos/properties/buildSchemes/additionalProperties/properties/iconColor"
                 },
@@ -2921,9 +2897,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "webpackConfig": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
@@ -3073,9 +3046,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "webpackConfig": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                 },
@@ -3213,9 +3183,6 @@
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                       },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                      },
                       "ignoreWarnings": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings"
                       },
@@ -3334,6 +3301,9 @@
                         },
                         "additionalProperties": false,
                         "description": "Allows you to configure electron wrapper app window"
+                      },
+                      "webpackConfig": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                       }
                     },
                     "additionalProperties": false
@@ -3453,9 +3423,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "ignoreWarnings": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/ios/properties/buildSchemes/additionalProperties/properties/ignoreWarnings",
                   "description": "Injects `inhibit_all_warnings` into Podfile"
@@ -3564,6 +3531,9 @@
                 "BrowserWindow": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/macos/properties/buildSchemes/additionalProperties/properties/BrowserWindow",
                   "description": "Allows you to configure electron wrapper app window"
+                },
+                "webpackConfig": {
+                  "$ref": "#/definitions/rnv.project/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                 }
               },
               "additionalProperties": false
@@ -3668,9 +3638,6 @@
                       },
                       "getJsBundleFile": {
                         "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
-                      },
-                      "webpackExcludedDirs": {
-                        "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
                       },
                       "electronConfig": {
                         "$ref": "#/definitions/rnv.project/properties/platforms/properties/macos/properties/buildSchemes/additionalProperties/properties/electronConfig"
@@ -3800,6 +3767,9 @@
                           }
                         },
                         "additionalProperties": false
+                      },
+                      "webpackConfig": {
+                        "$ref": "#/definitions/rnv.project/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                       }
                     },
                     "additionalProperties": false
@@ -3919,9 +3889,6 @@
                 "getJsBundleFile": {
                   "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/getJsBundleFile"
                 },
-                "webpackExcludedDirs": {
-                  "$ref": "#/definitions/rnv.project/properties/common/properties/buildSchemes/additionalProperties/properties/webpackExcludedDirs"
-                },
                 "electronConfig": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/macos/properties/buildSchemes/additionalProperties/properties/electronConfig",
                   "description": "Allows you to configure electron app as per https://www.electron.build/"
@@ -3936,6 +3903,9 @@
                 },
                 "templateVSProject": {
                   "$ref": "#/definitions/rnv.project/properties/platforms/properties/windows/properties/buildSchemes/additionalProperties/properties/templateVSProject"
+                },
+                "webpackConfig": {
+                  "$ref": "#/definitions/rnv.project/properties/platforms/properties/tizen/properties/buildSchemes/additionalProperties/properties/webpackConfig"
                 }
               },
               "additionalProperties": false

--- a/packages/core/src/schema/configFiles/engine.ts
+++ b/packages/core/src/schema/configFiles/engine.ts
@@ -26,12 +26,5 @@ export const zodConfigFileEngine = z
         plugins: z.record(z.string(), z.string()).describe('List of required plugins for this engine to work properly'),
         npm: zodEngineNpm,
         platforms: z.record(zodPlatformsKeys, zodEnginePlatform),
-        webpackExcludedDirs: z.optional(
-            z
-                .array(z.string())
-                .describe(
-                    'Allows to specify files or directories in the src folder that webpack should ignore when bundling code.'
-                )
-        ),
     })
     .partial();

--- a/packages/core/src/schema/platforms/fragments/base.ts
+++ b/packages/core/src/schema/platforms/fragments/base.ts
@@ -24,12 +24,5 @@ export const zodPlatformBaseFragment = z
             .describe('If set to `true` dedicated source map file will be generated alongside of compiled js bundle'),
         bundleIsDev: z.boolean().describe('If set to `true` debug build will be generated'),
         getJsBundleFile: z.string(),
-        webpackExcludedDirs: z.optional(
-            z
-                .array(z.string())
-                .describe(
-                    'Allows to specify files or directories in the src folder that webpack should ignore when bundling code. By default, the "pages" folder is excluded for web platforms that do not use next.js.'
-                )
-        ),
     })
     .partial();

--- a/packages/core/src/schema/platforms/fragments/webpack.ts
+++ b/packages/core/src/schema/platforms/fragments/webpack.ts
@@ -9,50 +9,12 @@ export const zodPlatformWebpackFragment = z
                     .array(z.string())
 
                     .describe('Allows you to inject custom script into html header'),
-                excludedDirs: z
+                excludedPaths: z
                     .array(z.string())
                     .describe(
                         'Allows to specify files or directories in the src folder that webpack should ignore when bundling code.'
                     ),
             })
             .partial(),
-
-        // webpackConfig: {
-        //     additionalProperties: true,
-        //     type: 'object',
-        //     properties: {
-        //         publicUrl: {
-        //             type: 'string',
-        //         },
-        //         metaTags: {
-        //             additionalProperties: true,
-        //             type: 'object',
-        //         },
-        //         customScripts: {
-        //             type: 'array',
-        //         },
-        //         extend: {
-        //             additionalProperties: true,
-        //             type: 'object',
-        //             description: 'Allows you to directly extend/override webpack config of your current platform',
-        //             examples: [
-        //                 {
-        //                     devtool: 'source-map',
-        //                 },
-        //                 {
-        //                     module: {
-        //                         rules: [
-        //                             {
-        //                                 test: /\.js$/,
-        //                                 use: ['source-map-loader'],
-        //                                 enforce: 'pre',
-        //                             },
-        //                         ],
-        //                     },
-        //                 },
-        //             ],
-        //         },
-        //     },
-        // },
     })
     .partial();

--- a/packages/core/src/schema/platforms/fragments/webpack.ts
+++ b/packages/core/src/schema/platforms/fragments/webpack.ts
@@ -9,6 +9,11 @@ export const zodPlatformWebpackFragment = z
                     .array(z.string())
 
                     .describe('Allows you to inject custom script into html header'),
+                excludedDirs: z
+                    .array(z.string())
+                    .describe(
+                        'Allows to specify files or directories in the src folder that webpack should ignore when bundling code.'
+                    ),
             })
             .partial(),
 

--- a/packages/core/src/schema/platforms/index.ts
+++ b/packages/core/src/schema/platforms/index.ts
@@ -44,12 +44,16 @@ const webSchema = createPlatformSchema(
 
 const macosSchema = createPlatformSchema(
     zodPlatformiOSFragment.merge(
-        zodPlatformReactNativeFragment.merge(zodTemplateXcodeFragment.merge(zodPlatformElectronFragment))
+        zodPlatformReactNativeFragment.merge(
+            zodTemplateXcodeFragment.merge(zodPlatformElectronFragment.merge(zodPlatformWebpackFragment))
+        )
     )
 );
 
 const windowsSchema = createPlatformSchema(
-    zodPlatformElectronFragment.merge(zodPlatformReactNativeFragment.merge(zodPlatformWindowsFragment))
+    zodPlatformElectronFragment.merge(
+        zodPlatformReactNativeFragment.merge(zodPlatformWindowsFragment.merge(zodPlatformWebpackFragment))
+    )
 );
 
 export const zodPlatformsSchema: AnyZodObject = z

--- a/packages/engine-rn-electron/renative.engine.json
+++ b/packages/engine-rn-electron/renative.engine.json
@@ -29,6 +29,5 @@
                 "devDependencies": {}
             }
         }
-    },
-    "webpackExcludedDirs": ["pages"]
+    }
 }

--- a/packages/engine-rn-web/renative.engine.json
+++ b/packages/engine-rn-web/renative.engine.json
@@ -29,6 +29,5 @@
         "tizenmobile": {},
         "chromecast": {},
         "kaios": {}
-    },
-    "webpackExcludedDirs": ["pages"]
+    }
 }

--- a/packages/sdk-webpack/src/adapter.ts
+++ b/packages/sdk-webpack/src/adapter.ts
@@ -132,9 +132,7 @@ const _mergeRule = (rnvRule: any, cnfRule: any) => {
     return Object.keys({ ...rnvRule, ...cnfRule }).reduce((merged: any, key: string) => {
         const rnvValue = rnvRule[key];
         const cnfValue = cnfRule[key];
-        if (!rnvValue && !cnfValue) {
-            return merged;
-        }
+
         if (_.isArray(rnvValue) && _.isArray(cnfValue)) {
             if (key === 'include') {
                 merged[key] = env.RNV_MODULE_PATHS
@@ -146,7 +144,7 @@ const _mergeRule = (rnvRule: any, cnfRule: any) => {
         } else if (_.isPlainObject(rnvValue) && _.isPlainObject(cnfValue)) {
             merged[key] = _mergeRule(rnvValue, cnfValue);
         } else {
-            merged[key] = cnfValue !== undefined ? cnfValue : rnvValue;
+            merged[key] = key in cnfRule ? cnfValue : rnvValue;
         }
 
         return merged;

--- a/packages/sdk-webpack/src/config/webpack.config.js
+++ b/packages/sdk-webpack/src/config/webpack.config.js
@@ -680,7 +680,7 @@ module.exports = function (webpackEnv) {
                                 tsBuildInfoFile: paths.appTsBuildInfoFile,
                                 exclude: [
                                     ...excludeTs,
-                                    (process.env.WEBPACK_EXCLUDED_PATHS || []).map((dir) => `src/${dir}`).join(','),
+                                    ...(process.env.WEBPACK_EXCLUDED_PATHS || '').split(',').map((dir) => `src/${dir}`),
                                 ],
                             },
                         },

--- a/packages/sdk-webpack/src/config/webpack.config.js
+++ b/packages/sdk-webpack/src/config/webpack.config.js
@@ -680,7 +680,7 @@ module.exports = function (webpackEnv) {
                                 tsBuildInfoFile: paths.appTsBuildInfoFile,
                                 exclude: [
                                     ...excludeTs,
-                                    (process.env.TS_EXCLUDE_SRC_DIRS || []).map((dir) => `src/${dir}`).join(','),
+                                    (process.env.WEBPACK_EXCLUDED_PATHS || []).map((dir) => `src/${dir}`).join(','),
                                 ],
                             },
                         },

--- a/packages/sdk-webpack/src/config/webpack.config.js
+++ b/packages/sdk-webpack/src/config/webpack.config.js
@@ -678,7 +678,10 @@ module.exports = function (webpackEnv) {
                                 noEmit: true,
                                 incremental: true,
                                 tsBuildInfoFile: paths.appTsBuildInfoFile,
-                                exclude: [...excludeTs, process.env.TS_EXCLUDE_SRC_DIRS],
+                                exclude: [
+                                    ...excludeTs,
+                                    (process.env.TS_EXCLUDE_SRC_DIRS || []).map((dir) => `src/${dir}`).join(','),
+                                ],
                             },
                         },
                         context: paths.appPath,

--- a/packages/sdk-webpack/src/env.ts
+++ b/packages/sdk-webpack/src/env.ts
@@ -39,15 +39,12 @@ export const EnvVars = {
             return { WEBPACK_TARGET: ctx.runtime.webpackTarget };
         }
     },
-    TS_EXCLUDE_SRC_DIRS: () => {
-        const ctx = getContext();
-        if (!ctx.platform) return;
-        const engine = ctx.runtime.enginesByPlatform[ctx.platform];
-        const excludedDirs =
-            ctx.buildConfig?.platforms?.[ctx.platform]?.webpackExcludedDirs ||
-            engine?.config?.webpackExcludedDirs ||
-            [];
-        return { TS_EXCLUDE_SRC_DIRS: excludedDirs.map((dir) => `src/${dir}`).join(',') };
+    WEBPACK_EXCLUDED_DIRS: () => {
+        const webpackConfig = getConfigProp('webpackConfig');
+
+        if (webpackConfig?.excludedDirs) {
+            return { WEBPACK_EXCLUDED_DIRS: webpackConfig?.excludedDirs };
+        }
     },
     RNV_EXTERNAL_PATHS: () => {
         const ctx = getContext();

--- a/packages/sdk-webpack/src/env.ts
+++ b/packages/sdk-webpack/src/env.ts
@@ -39,11 +39,11 @@ export const EnvVars = {
             return { WEBPACK_TARGET: ctx.runtime.webpackTarget };
         }
     },
-    WEBPACK_EXCLUDED_DIRS: () => {
+    WEBPACK_EXCLUDED_PATHS: () => {
         const webpackConfig = getConfigProp('webpackConfig');
 
-        if (webpackConfig?.excludedDirs) {
-            return { WEBPACK_EXCLUDED_DIRS: webpackConfig?.excludedDirs };
+        if (webpackConfig?.excludedPaths) {
+            return { WEBPACK_EXCLUDED_PATHS: webpackConfig?.excludedPaths };
         }
     },
     RNV_EXTERNAL_PATHS: () => {

--- a/packages/sdk-webpack/src/index.ts
+++ b/packages/sdk-webpack/src/index.ts
@@ -162,7 +162,7 @@ export const _runWebDevServer = async (c: RnvContext, enableRemoteDebugger?: boo
         ...EnvVars.PORT(),
         ...EnvVars.WEBPACK_TARGET(),
         ...EnvVars.RNV_EXTERNAL_PATHS(),
-        ...EnvVars.TS_EXCLUDE_SRC_DIRS(),
+        ...EnvVars.WEBPACK_EXCLUDED_DIRS(),
     };
 
     Object.keys(env).forEach((v) => {
@@ -199,7 +199,7 @@ export const buildCoreWebpackProject = async () => {
     const c = getContext();
     const { debug, debugIp } = c.program.opts();
     logDefault('buildCoreWebpackProject');
-    const env: Record<string, any> = {
+    const env: Env = {
         ...CoreEnvVars.BASE(),
         ...CoreEnvVars.RNV_EXTENSIONS(),
         ...EnvVars.RNV_MODULE_CONFIGS(),
@@ -208,7 +208,7 @@ export const buildCoreWebpackProject = async () => {
         ...EnvVars.PORT(),
         ...EnvVars.WEBPACK_TARGET(),
         ...EnvVars.RNV_EXTERNAL_PATHS(),
-        ...EnvVars.TS_EXCLUDE_SRC_DIRS(),
+        ...EnvVars.WEBPACK_EXCLUDED_DIRS(),
     };
     Object.keys(env).forEach((v) => {
         process.env[v] = env[v];

--- a/packages/sdk-webpack/src/index.ts
+++ b/packages/sdk-webpack/src/index.ts
@@ -162,7 +162,7 @@ export const _runWebDevServer = async (c: RnvContext, enableRemoteDebugger?: boo
         ...EnvVars.PORT(),
         ...EnvVars.WEBPACK_TARGET(),
         ...EnvVars.RNV_EXTERNAL_PATHS(),
-        ...EnvVars.WEBPACK_EXCLUDED_DIRS(),
+        ...EnvVars.WEBPACK_EXCLUDED_PATHS(),
     };
 
     Object.keys(env).forEach((v) => {
@@ -208,7 +208,7 @@ export const buildCoreWebpackProject = async () => {
         ...EnvVars.PORT(),
         ...EnvVars.WEBPACK_TARGET(),
         ...EnvVars.RNV_EXTERNAL_PATHS(),
-        ...EnvVars.WEBPACK_EXCLUDED_DIRS(),
+        ...EnvVars.WEBPACK_EXCLUDED_PATHS(),
     };
     Object.keys(env).forEach((v) => {
         process.env[v] = env[v];

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -98,7 +98,7 @@
             "engine": "engine-rn-electron",
             "assetFolderPlatform": "electron",
             "webpackConfig": {
-                "excludedDirs": ["pages"]
+                "excludedPaths": ["pages"]
             }
         },
         "windows": {

--- a/packages/template-starter/renative.json
+++ b/packages/template-starter/renative.json
@@ -96,7 +96,10 @@
         },
         "macos": {
             "engine": "engine-rn-electron",
-            "assetFolderPlatform": "electron"
+            "assetFolderPlatform": "electron",
+            "webpackConfig": {
+                "excludedDirs": ["pages"]
+            }
         },
         "windows": {
             "engine": "engine-rn-electron",


### PR DESCRIPTION
## Description

- remove cyclic dependency: engine -> sdk-webpack -> engine
- renamed & cleaned up configs
- add support for excluding full paths 
- combine TS_EXCLUDE_SRC_DIRS and webpackExcludedDirs into `excludedPaths`

## Related issues

- https://github.com/flexn-io/renative/commit/9e93b3b87dcb656092a7defcc90dcece0cbac0ea
- https://github.com/flexn-io/renative/commit/93bf7b9e5a91888c9a998064bbefba0044009c8d

## Npm releases

n/a
