### PR TITLE
fix target picking for android when only one sim is present

### DIFF
--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -117,10 +117,6 @@ export const getAndroidDeviceToRunOn = async () => {
             if (activeDeviceInfoArr.length === 1 && inactiveDeviceInfoArr.length === 0 && !target) {
                 chosenTarget = activeDeviceInfoArr[0].value;
                 logInfo(`Found only one active target: ${chalk().magenta(chosenTarget)}. Will use it.`);
-            } else if (activeDeviceInfoArr.length === 0 && inactiveDeviceInfoArr.length === 1 && !target) {
-                //If we have no active devices and only one AVD available let's just launch it.
-                chosenTarget = inactiveDeviceInfoArr[0].value;
-                logInfo(`Found only one target to launch: ${chalk().magenta(chosenTarget)}. Will use it.`);
             } else {
                 const response = await inquirerPrompt({
                     name: 'chosenTarget',
@@ -377,7 +373,6 @@ export const configureProject = async () => {
     fsWriteFileSync(path.join(appFolder, `app/src/main/assets/${outputFile}.bundle`), '{}');
 
     // console.log({ templateAndroid: c });
-
 
     // PLUGINS
     parsePlugins((plugin, pluginPlat, key) => {


### PR DESCRIPTION
## Description

- [Android, AndroidTV, Androidwear] when user has only 1 sim, rnv forgets to ask for sim when it should and just launches that one sim

## Related issues

- https://github.com/flexn-io/renative/issues/1372

## Npm releases

n/a
