### PR TITLE
add --local-template-path/ --localTemplatePath option to rnv new

### DIFF
--- a/packages/engine-core/src/taskOptions.ts
+++ b/packages/engine-core/src/taskOptions.ts
@@ -52,6 +52,12 @@ export const TaskOptions = createTaskOptionsMap([
         description: 'select the template version',
     },
     {
+        key: 'local-template-path',
+        altKey: 'localTemplatePath',
+        isValueType: true,
+        description: 'select the local template path (absolute)',
+    },
+    {
         key: 'title',
         isValueType: true,
         description: 'select the title of the app',

--- a/packages/engine-core/src/tasks/bootstrap/questions/installTemplate.ts
+++ b/packages/engine-core/src/tasks/bootstrap/questions/installTemplate.ts
@@ -45,6 +45,7 @@ const Question = async (data: NewProjectData) => {
 
     const c = getContext();
     const { templateVersion, projectTemplate } = c.program.opts();
+    let { localTemplatePath } = c.program.opts();
 
     const projectTemplates = c.buildConfig.projectTemplates || {}; // c.files.rnvConfigTemplates.config?.projectTemplates || {};
 
@@ -66,13 +67,12 @@ const Question = async (data: NewProjectData) => {
     options.push(customTemplate);
     options.push(localTemplate);
     options.push(noTemplate);
-    let localTemplatePath: string | undefined;
 
     inputs.template = {};
 
     if (checkInputValue(projectTemplate)) {
         inputs.template.packageName = projectTemplate;
-    } else {
+    } else if (!checkInputValue(localTemplatePath)) {
         const iRes = await inquirerPrompt({
             name: 'inputTemplate',
             type: 'list',
@@ -112,7 +112,7 @@ const Question = async (data: NewProjectData) => {
 
     const npmCacheDir = path.join(c.paths.project.dir, RnvFolderName.dotRnv, RnvFolderName.npmCache);
 
-    if (localTemplatePath) {
+    if (checkInputValue(localTemplatePath)) {
         if (!fsExistsSync(localTemplatePath)) {
             return Promise.reject(`Local template path ${localTemplatePath} does not exist`);
         }

--- a/packages/engine-core/src/tasks/bootstrap/taskNew.ts
+++ b/packages/engine-core/src/tasks/bootstrap/taskNew.ts
@@ -95,6 +95,7 @@ export default createTask({
         TaskOptions.projectName,
         TaskOptions.projectTemplate,
         TaskOptions.templateVersion,
+        TaskOptions.localTemplatePath,
         TaskOptions.title,
         TaskOptions.appVersion,
         TaskOptions.id,


### PR DESCRIPTION
## Description

- Being able to pass a local template to `rnv new `non-interactively using cli option

  Example:
`rnv new --local-template-path /Users/olenadiachenko/GitHub/renative/packages/template-starter`

## Related issues

- https://github.com/flexn-io/renative/issues/1658

## Npm releases

n/a
