### PR TITLE
fix --skip-dependency-check option being ignored

### DIFF
--- a/packages/core/src/tasks/taskOptions.ts
+++ b/packages/core/src/tasks/taskOptions.ts
@@ -232,6 +232,7 @@ export const RnvTaskCoreOptionPresets = createTaskOptionsPreset({
         RnvTaskOptions.json,
         RnvTaskOptions.noSummary,
         RnvTaskOptions.noIntro,
+        RnvTaskOptions.skipDependencyCheck,
     ],
 });
 


### PR DESCRIPTION
## Description

Fixes `--skip-dependency-check` option being ignored.

## Related issues

- https://github.com/flexn-io/renative/issues/1672

## Testing
Remove `react-native-permissions` from `app-harness/package.json`.
`npx rnv configure -p android` should interactively prompt about updating package.json.
`npx rnv configure -p android --skip-dependency-check` should succeed without any prompts.