### PR TITLE
fix --skip-dependency-check option being ignored

### DIFF
--- a/packages/core/src/tasks/taskOptions.ts
+++ b/packages/core/src/tasks/taskOptions.ts
@@ -232,6 +232,7 @@ export const RnvTaskCoreOptionPresets = createTaskOptionsPreset({
         RnvTaskOptions.json,
         RnvTaskOptions.noSummary,
         RnvTaskOptions.noIntro,
+        RnvTaskOptions.skipDependencyCheck,
     ],
 });
 


### PR DESCRIPTION
(cherry picked from commit 81e4feb2c118895ffeb6581d6a4ba06a53973a63)
Merge 1.1 to main after this is merged

