### PR TITLE
add offline mode option

### DIFF
--- a/packages/core/src/tasks/taskOptions.ts
+++ b/packages/core/src/tasks/taskOptions.ts
@@ -100,6 +100,10 @@ export const RnvTaskOptions = createTaskOptionsMap([
         description: 'Skips auto update of npm dependencies if mismatch found',
     },
     {
+        key: 'offline',
+        description: 'Run without connecting to the internet whenever possible',
+    },
+    {
         key: 'app-config-ID',
         altKey: 'appConfigID',
         shortcut: 'c',
@@ -233,6 +237,7 @@ export const RnvTaskCoreOptionPresets = createTaskOptionsPreset({
         RnvTaskOptions.noSummary,
         RnvTaskOptions.noIntro,
         RnvTaskOptions.skipDependencyCheck,
+        RnvTaskOptions.offline,
     ],
 });
 

--- a/packages/engine-core/src/taskHelpers.ts
+++ b/packages/engine-core/src/taskHelpers.ts
@@ -4,9 +4,10 @@ import {
     getContext,
     installPackageDependencies,
     logDefault,
+    logInfo,
     overrideTemplatePlugins,
 } from '@rnv/core';
-import { configureFonts } from '@rnv/sdk-utils';
+import { configureFonts, isOfflineMode } from '@rnv/sdk-utils';
 
 export const installPackageDependenciesAndPlugins = async () => {
     logDefault('installPackageDependenciesAndPlugins');
@@ -21,7 +22,13 @@ export const installPackageDependenciesAndPlugins = async () => {
 
 export const checkAndInstallIfRequired = async () => {
     const ctx = getContext();
-    if (ctx.program.opts().skipDependencyCheck) return true;
+    if (isOfflineMode('install package dependencies and plugins')) {
+        return true;
+    }
+    if (ctx.program.opts().skipDependencyCheck) {
+        logInfo(`Skipping installing package dependencies and plugins due to --skip-dependency-check option`);
+        return true;
+    }
     const isNmInstalled = areNodeModulesInstalled();
     if (isNmInstalled && !ctx._requiresNpmInstall) {
         return true;

--- a/packages/sdk-react-native/src/iosRunner.ts
+++ b/packages/sdk-react-native/src/iosRunner.ts
@@ -20,6 +20,7 @@ import { EnvVars } from './env';
 import shellQuote from 'shell-quote';
 import path from 'path';
 import crypto from 'crypto';
+import { isOfflineMode } from '@rnv/sdk-utils';
 
 export const packageReactNativeIOS = (isDev = false) => {
     const c = getContext();
@@ -126,6 +127,9 @@ const checkIfPodsIsRequired = (
     c: RnvContext,
     forceUpdatePods: boolean
 ): { result: boolean; reason: string; code: number } => {
+    if (isOfflineMode()) {
+        return { result: false, reason: 'You passed --offline option', code: 7 };
+    }
     if (c.runtime._skipNativeDepResolutions) {
         return { result: false, reason: `Command ${getCurrentCommand(true)} explicitly skips pod checks`, code: 1 };
     }

--- a/packages/sdk-utils/src/getCliOptions.ts
+++ b/packages/sdk-utils/src/getCliOptions.ts
@@ -1,0 +1,12 @@
+import { getContext, logInfo } from '@rnv/core';
+
+export const isOfflineMode = (logMessage?: string) => {
+    if (getContext().program.opts().offline) {
+        if (logMessage) {
+            logInfo(`Skipping "${logMessage}" due to --offline option`);
+        }
+        return true;
+    } else {
+        return false;
+    }
+};

--- a/packages/sdk-utils/src/index.ts
+++ b/packages/sdk-utils/src/index.ts
@@ -5,3 +5,4 @@ export * from './ipUtils';
 export * from './utils';
 export * from './target';
 export * from './axiosUtils';
+export * from './getCliOptions';


### PR DESCRIPTION
## Description
Adds an `--offline` option that makes rnv skip actions that connect to the internet. Currently it only skips installing missing npm packages and running pod actions.

## Related issues
https://github.com/flexn-io/renative/issues/1677

## Testing
Remove `react-native-permissions` from `app-harness/package.json`.
`npx rnv configure -p ios` should interactively prompt about updating package.json.
`npx rnv configure -p ios --offline` should log that it's skipping installation and pod actions due to `--offline`. It may fail if pods were not installed before.
