### PR TITLE
fix_missing_default_target_android

### DIFF
--- a/packages/sdk-android/src/runner.ts
+++ b/packages/sdk-android/src/runner.ts
@@ -112,21 +112,12 @@ export const getAndroidDeviceToRunOn = async () => {
 
             const choices = [...activeDeviceInfoArr, ...inactiveDeviceInfoArr];
 
-            let chosenTarget: string;
-
-            if (activeDeviceInfoArr.length === 1 && inactiveDeviceInfoArr.length === 0 && !target) {
-                chosenTarget = activeDeviceInfoArr[0].value;
-                logInfo(`Found only one active target: ${chalk().magenta(chosenTarget)}. Will use it.`);
-            } else {
-                const response = await inquirerPrompt({
-                    name: 'chosenTarget',
-                    type: 'list',
-                    message: 'What target would you like to use?',
-                    choices,
-                });
-                chosenTarget = response?.chosenTarget;
-            }
-
+            const { chosenTarget } = await inquirerPrompt({
+                name: 'chosenTarget',
+                type: 'list',
+                message: 'What target would you like to use?',
+                choices,
+            });
             if (chosenTarget) {
                 const dev = activeDevices.find((d) => d.name === chosenTarget);
                 if (dev) return dev;


### PR DESCRIPTION
## Description

- If there is no default targets and at least one simulator is active -> app is installed and launched on active simulator (should ask to choose)

## Related issues

- https://github.com/flexn-io/renative/issues/1372#issuecomment-2326607712

## Npm releases

n/a
