### PR TITLE
[kaios] white blank screen when running app-harness

### DIFF
--- a/packages/app-harness/src/components/Player/index.kaios.tsx
+++ b/packages/app-harness/src/components/Player/index.kaios.tsx
@@ -1,0 +1,5 @@
+import { Text } from 'react-native';
+
+export const Player = () => {
+    return <Text style={{ color: 'black' }}>Not supported</Text>;
+};


### PR DESCRIPTION
## Description

- Add exception for react-native player

## Related issues

- https://github.com/flexn-io/renative/issues/1695

## Npm releases

n/a
