### PR TITLE
Add error for webos sdk

### DIFF
--- a/packages/sdk-webos/src/__tests__/cli.test.ts
+++ b/packages/sdk-webos/src/__tests__/cli.test.ts
@@ -76,11 +76,6 @@ describe('checkAndConfigureWebosSdks', () => {
         // GIVEN
         const mockContext = {
             platform: 'webos',
-            // buildConfig: {
-            //     sdks: {
-            //         WEBOS_SDK: '/path/to/sdk',
-            //     },
-            // },
             cli: {},
         };
         (core.getContext as jest.Mock).mockReturnValue(mockContext);

--- a/packages/sdk-webos/src/__tests__/cli.test.ts
+++ b/packages/sdk-webos/src/__tests__/cli.test.ts
@@ -47,7 +47,7 @@ describe('checkAndConfigureWebosSdks', () => {
         const reject = installer.checkAndConfigureWebosSdks();
 
         // THEN
-        await expect(reject).rejects.toThrow('No Webos SDK found. Check if it is installed.');
+        await expect(reject).rejects.toThrow('No Webos CLI found. Check if it is installed.');
     });
     it('checks for old version of CLI(installed manually and placed in SDK folder)', async () => {
         // GIVEN
@@ -76,11 +76,11 @@ describe('checkAndConfigureWebosSdks', () => {
         // GIVEN
         const mockContext = {
             platform: 'webos',
-            buildConfig: {
-                sdks: {
-                    WEBOS_SDK: '/path/to/sdk',
-                },
-            },
+            // buildConfig: {
+            //     sdks: {
+            //         WEBOS_SDK: '/path/to/sdk',
+            //     },
+            // },
             cli: {},
         };
         (core.getContext as jest.Mock).mockReturnValue(mockContext);

--- a/packages/sdk-webos/src/__tests__/deviceManager.test.ts
+++ b/packages/sdk-webos/src/__tests__/deviceManager.test.ts
@@ -16,8 +16,11 @@ afterEach(() => {
 describe('launchWebOSimulator', () => {
     it('should fail if webos SDK path is not defined', async () => {
         //GIVEN
+        const ctx = getContext();
+        ctx.platform = 'webos';
+        ctx.paths.workspace.config = '/path/test';
         const target = true;
-        const errorMessage = `c.buildConfig.sdks.WEBOS_SDK undefined`;
+        const errorMessage = `Your webos SDK path is not configured. Please update your /path/test file`;
 
         jest.mocked(getRealPath).mockReturnValue(undefined);
 

--- a/packages/sdk-webos/src/__tests__/deviceManager.test.ts
+++ b/packages/sdk-webos/src/__tests__/deviceManager.test.ts
@@ -18,9 +18,9 @@ describe('launchWebOSimulator', () => {
         //GIVEN
         const ctx = getContext();
         ctx.platform = 'webos';
-        ctx.paths.workspace.config = '/path/test';
+        ctx.paths.workspace.config = '/path/test/renative';
         const target = true;
-        const errorMessage = `Your webos SDK path is not configured. Please update your /path/test file`;
+        const errorMessage = `Your webos SDK path is not configured. If you want to run simulator please update your /path/test/renative file with simulator path.`;
 
         jest.mocked(getRealPath).mockReturnValue(undefined);
 

--- a/packages/sdk-webos/src/deviceManager.ts
+++ b/packages/sdk-webos/src/deviceManager.ts
@@ -38,7 +38,9 @@ export const launchWebOSimulator = async (target: string | boolean) => {
     const c = getContext();
     const webosSdkPath = getRealPath(c.buildConfig?.sdks?.WEBOS_SDK);
     if (!webosSdkPath) {
-        return Promise.reject(`c.buildConfig.sdks.WEBOS_SDK undefined`);
+        return Promise.reject(
+            `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
+            );
     }
     const availableSimulatorVersions = getDirectories(path.join(webosSdkPath, 'Simulator'));
 
@@ -130,8 +132,11 @@ const launchAppOnSimulator = async (c: RnvContext, appPath: string) => {
 
     const webosSdkPath = getRealPath(c.buildConfig?.sdks?.WEBOS_SDK);
 
+
     if (!webosSdkPath) {
-        return Promise.reject(`c.buildConfig.sdks.WEBOS_SDK undefined`);
+        return Promise.reject(
+            `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
+        );
     }
 
     const simulatorDirPath = path.join(webosSdkPath, 'Simulator');
@@ -220,7 +225,9 @@ export const listWebOSTargets = async () => {
 
     const webosSdkPath = getRealPath(c.buildConfig?.sdks?.WEBOS_SDK);
     if (!webosSdkPath) {
-        return Promise.reject(`c.buildConfig.sdks.WEBOS_SDK undefined`);
+        return Promise.reject(
+            `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
+            );
     }
     const availableSimulatorVersions = getDirectories(path.join(webosSdkPath, 'Simulator'));
     availableSimulatorVersions.map((a) => {

--- a/packages/sdk-webos/src/deviceManager.ts
+++ b/packages/sdk-webos/src/deviceManager.ts
@@ -20,6 +20,7 @@ import {
     getConfigProp,
     getAppFolder,
     getContext,
+    logError,
 } from '@rnv/core';
 import { WebosDevice } from './types';
 import {
@@ -40,7 +41,7 @@ export const launchWebOSimulator = async (target: string | boolean) => {
     if (!webosSdkPath) {
         return Promise.reject(
             `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
-            );
+        );
     }
     const availableSimulatorVersions = getDirectories(path.join(webosSdkPath, 'Simulator'));
 
@@ -132,10 +133,9 @@ const launchAppOnSimulator = async (c: RnvContext, appPath: string) => {
 
     const webosSdkPath = getRealPath(c.buildConfig?.sdks?.WEBOS_SDK);
 
-
     if (!webosSdkPath) {
         return Promise.reject(
-            `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
+            `Your ${c.platform} SDK path is not configured. If you want to run simulator please update your ${c.paths.workspace.config} file with simulator path.`
         );
     }
 
@@ -227,7 +227,7 @@ export const listWebOSTargets = async () => {
     if (!webosSdkPath) {
         return Promise.reject(
             `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
-            );
+        );
     }
     const availableSimulatorVersions = getDirectories(path.join(webosSdkPath, 'Simulator'));
     availableSimulatorVersions.map((a) => {
@@ -333,7 +333,11 @@ export const runWebosSimOrDevice = async () => {
                 return installAndLaunchApp(response.chosenDevice, appPath, tId);
             }
         } else {
-            return launchAppOnSimulator(c, appLocation);
+            try {
+                return await launchAppOnSimulator(c, appLocation);
+            } catch (error) {
+                return logError(`${error}`);
+            }
         }
     } else {
         // Target specified, using that

--- a/packages/sdk-webos/src/deviceManager.ts
+++ b/packages/sdk-webos/src/deviceManager.ts
@@ -40,7 +40,7 @@ export const launchWebOSimulator = async (target: string | boolean) => {
     const webosSdkPath = getRealPath(c.buildConfig?.sdks?.WEBOS_SDK);
     if (!webosSdkPath) {
         return Promise.reject(
-            `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
+            `Your ${c.platform} SDK path is not configured. If you want to run simulator please update your ${c.paths.workspace.config} file with simulator path.`
         );
     }
     const availableSimulatorVersions = getDirectories(path.join(webosSdkPath, 'Simulator'));

--- a/packages/sdk-webos/src/installer.ts
+++ b/packages/sdk-webos/src/installer.ts
@@ -40,10 +40,6 @@ export const checkAndConfigureWebosSdks = async () => {
     const clipathNewVersion = await getCliDirPath();
     const clipathOldVersion = sdk && path.join(sdk, 'CLI/bin');
 
-    if (!fsExistsSync(sdk)) {
-        throw new Error('No Webos SDK found. Check if it is installed.');
-    }
-
     if (sdk && fsExistsSync(clipathOldVersion)) {
         c.cli[CLI_WEBOS_ARES] = getRealPath(path.join(sdk, `CLI/bin/ares${isSystemWin ? '.cmd' : ''}`));
         c.cli[CLI_WEBOS_ARES_PACKAGE] = getRealPath(path.join(sdk, `CLI/bin/ares-package${isSystemWin ? '.cmd' : ''}`));
@@ -56,7 +52,7 @@ export const checkAndConfigureWebosSdks = async () => {
             path.join(sdk, `CLI/bin/ares-device-info${isSystemWin ? '.cmd' : ''}`)
         );
         c.cli[CLI_WEBOS_ARES_NOVACOM] = getRealPath(path.join(sdk, `CLI/bin/ares-novacom${isSystemWin ? '.cmd' : ''}`));
-    } else if (sdk && clipathNewVersion && fsExistsSync(clipathNewVersion + '/ares')) {
+    } else if ( clipathNewVersion && fsExistsSync(clipathNewVersion + '/ares')) {
         c.cli[CLI_WEBOS_ARES] = getRealPath(path.join(clipathNewVersion, `ares${isSystemWin ? '.cmd' : ''}`));
         c.cli[CLI_WEBOS_ARES_PACKAGE] = getRealPath(
             path.join(clipathNewVersion, `ares-package${isSystemWin ? '.cmd' : ''}`)
@@ -145,12 +141,6 @@ const _attemptAutoFix = async (c: RnvContext, shouldThrow?: boolean) => {
 
             return true;
         }
-    }
-
-    if (shouldThrow) {
-        throw new Error(
-            `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
-        );
     }
     logError(`_attemptAutoFix: no sdks found. searched at: ${SDK_LOCATIONS.join(', ')}`);
 

--- a/packages/sdk-webos/src/installer.ts
+++ b/packages/sdk-webos/src/installer.ts
@@ -52,7 +52,7 @@ export const checkAndConfigureWebosSdks = async () => {
             path.join(sdk, `CLI/bin/ares-device-info${isSystemWin ? '.cmd' : ''}`)
         );
         c.cli[CLI_WEBOS_ARES_NOVACOM] = getRealPath(path.join(sdk, `CLI/bin/ares-novacom${isSystemWin ? '.cmd' : ''}`));
-    } else if ( clipathNewVersion && fsExistsSync(clipathNewVersion + '/ares')) {
+    } else if (clipathNewVersion && fsExistsSync(clipathNewVersion + '/ares')) {
         c.cli[CLI_WEBOS_ARES] = getRealPath(path.join(clipathNewVersion, `ares${isSystemWin ? '.cmd' : ''}`));
         c.cli[CLI_WEBOS_ARES_PACKAGE] = getRealPath(
             path.join(clipathNewVersion, `ares-package${isSystemWin ? '.cmd' : ''}`)
@@ -144,6 +144,11 @@ const _attemptAutoFix = async (c: RnvContext, shouldThrow?: boolean) => {
     }
     logError(`_attemptAutoFix: no sdks found. searched at: ${SDK_LOCATIONS.join(', ')}`);
 
+    if (shouldThrow) {
+        throw new Error(
+            `Your ${c.platform} SDK path is not configured. Please update your ${c.paths.workspace.config} file`
+        );
+    }
     // const setupInstance = PlatformSetup(c);
     // await setupInstance.askToInstallSDK(sdkPlatform);
     generateBuildConfig();

--- a/packages/sdk-webos/src/tasks/taskSdkConfigure.ts
+++ b/packages/sdk-webos/src/tasks/taskSdkConfigure.ts
@@ -7,7 +7,7 @@ export default createTask({
     isPrivate: true,
     fn: async () => {
         await checkAndConfigureWebosSdks();
-        await checkWebosSdk(true);
+        await checkWebosSdk();
     },
     task: RnvTaskName.sdkConfigure,
     platforms: SdkPlatforms,


### PR DESCRIPTION
## Description

- Change webos sdk error prompt so that you could run renative on webos device without adding sdk path.

## Related issues

- https://github.com/flexn-io/renative/issues/1657

## Npm releases

n/a
