### PR TITLE
Fix/apple target launch

### DIFF
--- a/packages/sdk-apple/src/tasks/taskTargetLaunch.ts
+++ b/packages/sdk-apple/src/tasks/taskTargetLaunch.ts
@@ -5,7 +5,7 @@ import { SdkPlatforms } from '../common';
 
 export default createTask({
     description: 'Launch specific ios target',
-    dependsOn: [RnvTaskName.workspaceConfigure],
+    dependsOn: [RnvTaskName.projectConfigure],
     fn: async () => {
         const target = await getTargetWithOptionalPrompt();
         return launchAppleSimulator(target);


### PR DESCRIPTION
## Description

- [REGRESSION] [ios/tvos] target launch returns empty list when no/wrong targets are defined 

## Related issues

- https://github.com/flexn-io/renative/issues/1729

## Npm releases

n/a
