### PR TITLE
Being able to change tizen certificate from default RNV to custom ones

### DIFF
--- a/packages/core/src/enums/taskName.ts
+++ b/packages/core/src/enums/taskName.ts
@@ -61,4 +61,5 @@ export const RnvTaskName = {
     telemetryStatus: 'telemetry status',
     config: 'config',
     patchReset: 'patch reset',
+    tizenCertificate: 'tizen certificate',
 } as const;

--- a/packages/sdk-tizen/src/deviceManager.ts
+++ b/packages/sdk-tizen/src/deviceManager.ts
@@ -417,9 +417,7 @@ export const runTizenSimOrDevice = async () => {
     const intermediate = path.join(tDir, 'intermediate');
     const tOut = path.join(tDir, 'output');
     const tId = getConfigProp('id');
-    console.log('certProfile here is:');
-    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile; // default should be gotten from renative.json
-    console.log(certProfile);
+    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile;
 
     const wgt = `${appName}.wgt`;
     // the tizen CLI cannot handle .wgt files with spaces correctly.

--- a/packages/sdk-tizen/src/deviceManager.ts
+++ b/packages/sdk-tizen/src/deviceManager.ts
@@ -247,7 +247,7 @@ export const createDevelopTizenCertificate = (c: RnvContext) =>
         )
             .then(() =>
                 addDevelopTizenCertificate(c, {
-                    profileName: DEFAULTS.certificateProfile,
+                    profileName: getConfigProp('certificateProfile') || DEFAULTS.certificateProfile,
                     certPath: path.join(certDirPath, `${certFilename}.p12`),
                     certPassword,
                 })
@@ -417,7 +417,9 @@ export const runTizenSimOrDevice = async () => {
     const intermediate = path.join(tDir, 'intermediate');
     const tOut = path.join(tDir, 'output');
     const tId = getConfigProp('id');
-    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile;
+    console.log('certProfile here is:');
+    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile; // default should be gotten from renative.json
+    console.log(certProfile);
 
     const wgt = `${appName}.wgt`;
     // the tizen CLI cannot handle .wgt files with spaces correctly.

--- a/packages/sdk-tizen/src/index.ts
+++ b/packages/sdk-tizen/src/index.ts
@@ -6,10 +6,11 @@ export * from './constants';
 import taskTargetLaunch from './tasks/taskTargetLaunch';
 import taskTargetList from './tasks/taskTargetList';
 import taskSdkConfigure from './tasks/taskSdkConfigure';
+import taskChangeCertificate from './tasks/taskChangeCertificate';
 import { GetContextType, createRnvModule } from '@rnv/core';
 
 const RnvModule = createRnvModule({
-    tasks: [taskTargetLaunch, taskTargetList, taskSdkConfigure] as const,
+    tasks: [taskTargetLaunch, taskTargetList, taskSdkConfigure, taskChangeCertificate] as const,
     name: '@rnv/sdk-tizen',
     type: 'internal',
 });

--- a/packages/sdk-tizen/src/runner.ts
+++ b/packages/sdk-tizen/src/runner.ts
@@ -47,7 +47,7 @@ export const checkTizenStudioCert = async (): Promise<boolean> => {
         await execCLI(
             CLI_TIZEN,
             `security-profiles list -n ${getConfigProp('certificateProfile') || DEFAULTS.certificateProfile}`
-        ); // default should be gotten from renative.json
+        );
         return true;
     } catch (e) {
         return false;
@@ -77,7 +77,7 @@ export const configureTizenGlobal = () =>
                         const certPassword = '1234';
 
                         addDevelopTizenCertificate(c, {
-                            profileName: getConfigProp('certificateProfile') || DEFAULTS.certificateProfile, // default should be gotten from renative.json
+                            profileName: getConfigProp('certificateProfile') || DEFAULTS.certificateProfile,
                             certPath: path.join(certDirPath, `${certFilename}.p12`),
                             certPassword,
                         })
@@ -172,7 +172,7 @@ export const buildTizenProject = async () => {
 
     if (!platform) return;
 
-    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile; // default should be gotten from renative.json
+    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile;
     const tDir = getPlatformProjectDir()!;
 
     await buildCoreWebpackProject();

--- a/packages/sdk-tizen/src/runner.ts
+++ b/packages/sdk-tizen/src/runner.ts
@@ -44,7 +44,10 @@ const DEFAULT_CERTIFICATE_NAME_WITH_EXTENSION = `${DEFAULT_CERTIFICATE_NAME}.p12
 
 export const checkTizenStudioCert = async (): Promise<boolean> => {
     try {
-        await execCLI(CLI_TIZEN, `security-profiles list -n ${DEFAULTS.certificateProfile}`);
+        await execCLI(
+            CLI_TIZEN,
+            `security-profiles list -n ${getConfigProp('certificateProfile') || DEFAULTS.certificateProfile}`
+        ); // default should be gotten from renative.json
         return true;
     } catch (e) {
         return false;
@@ -74,7 +77,7 @@ export const configureTizenGlobal = () =>
                         const certPassword = '1234';
 
                         addDevelopTizenCertificate(c, {
-                            profileName: DEFAULTS.certificateProfile,
+                            profileName: getConfigProp('certificateProfile') || DEFAULTS.certificateProfile, // default should be gotten from renative.json
                             certPath: path.join(certDirPath, `${certFilename}.p12`),
                             certPassword,
                         })
@@ -169,7 +172,7 @@ export const buildTizenProject = async () => {
 
     if (!platform) return;
 
-    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile;
+    const certProfile = getConfigProp('certificateProfile') || DEFAULTS.certificateProfile; // default should be gotten from renative.json
     const tDir = getPlatformProjectDir()!;
 
     await buildCoreWebpackProject();

--- a/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
+++ b/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
@@ -1,0 +1,28 @@
+import { createTask, RnvTaskName } from '@rnv/core';
+import { SdkPlatforms } from '../constants';
+import fs from 'fs';
+export default createTask({
+    description: 'Change tizen certificate',
+    fn: async ({ ctx }) => {
+        console.log('good');
+
+        // bad approach?
+        ctx.paths.appConfig.configs.forEach(async (config: string) => {
+            if (config.includes('base')) {
+                const configFile = await JSON.parse(fs.readFileSync(config, 'utf-8'));
+
+                configFile.platforms.tizen.certificateProfile = 'newCert';
+                configFile.platforms.tizenwatch.certificateProfile = 'newCert';
+                configFile.platforms.tizenmobile.certificateProfile = 'newCert';
+
+                fs.writeFileSync(config, JSON.stringify(configFile, null, 2));
+            }
+        });
+
+        // should do a simple thing - update core/src/schema/defaults.ts certificateProfile key
+        // AND update certificateProfile key in template-starter/appConfigs/base/renative.json platforms.tizen, platforms.tizenwatch and platforms.tizenmobile
+    },
+    task: RnvTaskName.tizenCertificate,
+    platforms: SdkPlatforms,
+    isGlobalScope: true,
+});

--- a/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
+++ b/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
@@ -4,6 +4,7 @@ import { checkTizenStudioCert } from '../runner';
 
 export default createTask({
     description: 'Change tizen certificate',
+    dependsOn: [RnvTaskName.appConfigure],
     fn: async ({ ctx }) => {
         for (const config of ctx.paths.appConfig.configs) {
             if (config.includes('base')) {

--- a/packages/template-starter/appConfigs/base/renative.json
+++ b/packages/template-starter/appConfigs/base/renative.json
@@ -209,7 +209,7 @@
         "tizen": {
             "appName": "RNVanillaTV",
             "entryFile": "index",
-            "certificateProfile": "newCert",
+            "certificateProfile": "RNVanillaCert",
             "package": "NkVRhWHJSX",
             "id": "NkVRhWHJSX.RNVanillaTV",
             "buildSchemes": {
@@ -225,7 +225,7 @@
         "tizenwatch": {
             "appName": "RNVanillaWatch",
             "entryFile": "index",
-            "certificateProfile": "newCert",
+            "certificateProfile": "RNVanillaCert",
             "package": "cHIP2fIRQZ",
             "id": "cHIP2fIRQZ.RNVanillaWatch",
             "buildSchemes": {
@@ -241,7 +241,7 @@
         "tizenmobile": {
             "appName": "RNVanillaMobile",
             "entryFile": "index",
-            "certificateProfile": "newCert",
+            "certificateProfile": "RNVanillaCert",
             "package": "PauodvCU2r",
             "id": "PauodvCU2r.RNVanillaMobile",
             "buildSchemes": {

--- a/packages/template-starter/appConfigs/base/renative.json
+++ b/packages/template-starter/appConfigs/base/renative.json
@@ -209,7 +209,7 @@
         "tizen": {
             "appName": "RNVanillaTV",
             "entryFile": "index",
-            "certificateProfile": "RNVanillaCert",
+            "certificateProfile": "newCert",
             "package": "NkVRhWHJSX",
             "id": "NkVRhWHJSX.RNVanillaTV",
             "buildSchemes": {
@@ -225,7 +225,7 @@
         "tizenwatch": {
             "appName": "RNVanillaWatch",
             "entryFile": "index",
-            "certificateProfile": "RNVanillaCert",
+            "certificateProfile": "newCert",
             "package": "cHIP2fIRQZ",
             "id": "cHIP2fIRQZ.RNVanillaWatch",
             "buildSchemes": {
@@ -241,7 +241,7 @@
         "tizenmobile": {
             "appName": "RNVanillaMobile",
             "entryFile": "index",
-            "certificateProfile": "RNVanillaCert",
+            "certificateProfile": "newCert",
             "package": "PauodvCU2r",
             "id": "PauodvCU2r.RNVanillaMobile",
             "buildSchemes": {


### PR DESCRIPTION
## Description

- Currently if a user wants to use a custom tizen certificate, he can manaully change it//add it in appConfigs/app/renative.json platforms.tizen, platforms.tizenmobile or platforms.tizenwatch objects, certificateProfile key. But it still checks for the default RNV certificate in some places (first photo - running `rnv run -p tizen`. Checks for RNVanillaCert at the start of it, even though it was changed to custom certificate fakeCert, in renative.json, which is visible in the second picture in the CLI command).
 
<img width="877" alt="Screenshot 2024-09-27 at 07 47 56" src="https://github.com/user-attachments/assets/392651f9-85b7-4edc-ab46-7351c402627b">

<img width="1260" alt="Screenshot 2024-09-27 at 07 48 45" src="https://github.com/user-attachments/assets/ef23e0a7-eec7-4e13-9bdd-1e7f0d792e68">

For testing:
Added new command for tizen:
`npx rnv tizen certificate` it change default certificate to the new custom one

## Related issues

- #1712 

## Npm releases

n/a
