### PR TITLE
Fix change tizen certificate command in new project

### DIFF
--- a/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
+++ b/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
@@ -8,7 +8,6 @@ export default createTask({
     fn: async ({ ctx }) => {
         for (const config of ctx.paths.appConfig.configs) {
             if (config.includes('base')) {
-                const configFile = await JSON.parse(fs.readFileSync(config, 'utf-8'));
                 const { confirm } = await inquirerPrompt({
                     message:
                         'Tizen - used certificate change. NOTE: you must create the certificate first through the tizens certificate-manager. Continue?',
@@ -32,6 +31,29 @@ export default createTask({
                 if (name === '') {
                     logInfo('No certificate name entered.');
                     return;
+                }
+
+                if (!fs.existsSync(config)) {
+                    const configContent = JSON.stringify(
+                        {
+                            platforms: {
+                                [platform]: {
+                                    certificateProfile: name,
+                                },
+                            },
+                        },
+                        null,
+                        2
+                    );
+
+                    fs.writeFileSync(config, configContent);
+                    return;
+                }
+
+                const configFile = await JSON.parse(fs.readFileSync(config, 'utf-8'));
+
+                if (!configFile.platforms[platform]) {
+                    configFile.platforms[platform] = {};
                 }
 
                 configFile.platforms[`${platform}`].certificateProfile = name;


### PR DESCRIPTION
## Description

Fix change tizen certificate in new project

To test it:
- in monorepo run `yarn watch`
- create new project
- rnv link
- run `npx rnv tizen certificate`
- follow instructions

## Related issues

- https://github.com/flexn-io/renative/issues/1712

## Npm releases

n/a
