### PR TITLE
Fix tizen certificate edgecases

### DIFF
--- a/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
+++ b/packages/sdk-tizen/src/tasks/taskChangeCertificate.ts
@@ -17,11 +17,15 @@ export default createTask({
                 if (!confirm) {
                     return;
                 }
-                const { platform } = await inquirerPrompt({
+                const { selectedPlatforms } = await inquirerPrompt({
                     message: 'For which platform do you want to set the new certificate?',
-                    type: 'list',
-                    name: 'platform',
-                    choices: ['tizen', 'tizenwatch', 'tizenmobile'],
+                    type: 'checkbox',
+                    name: 'selectedPlatforms',
+                    choices: ctx.buildConfig.defaults?.supportedPlatforms?.filter((platform) =>
+                        platform.includes('tizen')
+                    ),
+                    pageSize: 20,
+                    validate: (val) => !!val.length || 'Please select at least a platform',
                 });
                 const { name } = await inquirerPrompt({
                     message: 'Enter the new certificate name:',
@@ -37,7 +41,7 @@ export default createTask({
                     const configContent = JSON.stringify(
                         {
                             platforms: {
-                                [platform]: {
+                                [selectedPlatforms[0]]: {
                                     certificateProfile: name,
                                 },
                             },
@@ -47,16 +51,17 @@ export default createTask({
                     );
 
                     fs.writeFileSync(config, configContent);
-                    return;
                 }
 
                 const configFile = await JSON.parse(fs.readFileSync(config, 'utf-8'));
 
-                if (!configFile.platforms[platform]) {
-                    configFile.platforms[platform] = {};
-                }
+                selectedPlatforms.forEach((platform: string) => {
+                    if (!configFile.platforms[platform]) {
+                        configFile.platforms[platform] = {};
+                    }
 
-                configFile.platforms[`${platform}`].certificateProfile = name;
+                    configFile.platforms[`${platform}`].certificateProfile = name;
+                });
 
                 fs.writeFileSync(config, JSON.stringify(configFile, null, 2));
 


### PR DESCRIPTION
## Description

- Fixed so that you can only selected existing tizen platforms. Also you can now select multiple platforms.

## Related issues

- https://github.com/flexn-io/renative/issues/1762

## Npm releases

n/a
