### PR TITLE
Fix and improve metro config merging

### DIFF
--- a/packages/engine-rn-macos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-macos/src/adapters/metroAdapter.ts
@@ -79,6 +79,7 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
                     .concat(config?.resolver?.blockList || [])
                     .concat(config?.resolver?.blacklistRE || [])
             ),
+            blacklistRE: undefined, // must be reset to prevent it from being processed by metro
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
         },
         watchFolders,

--- a/packages/engine-rn-macos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-macos/src/adapters/metroAdapter.ts
@@ -24,8 +24,8 @@ function escapeRegExp(pattern: RegExp | string) {
     throw new Error(`Unexpected blacklist pattern: ${pattern}`);
 }
 
-function blacklist(additionalBlacklist: RegExp[]) {
-    return new RegExp(`(${(additionalBlacklist || []).concat(sharedBlacklist).map(escapeRegExp).join('|')})$`);
+function blocklist(additionalBlacklist: RegExp[]) {
+    return [...additionalBlacklist, ...sharedBlacklist].map((regexp) => new RegExp(escapeRegExp(regexp)));
 }
 
 export const withRNVMetro = (config: InputConfig): InputConfig => {
@@ -46,24 +46,6 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
 
     const exts: string = env.RNV_EXTENSIONS || '';
 
-    let blacklistRE = [
-        blacklist([
-            /platformBuilds\/.*/,
-            /buildHooks\/.*/,
-            /projectConfig\/.*/,
-            /website\/.*/,
-            /appConfigs\/.*/,
-            /renative.local.*/,
-            /metro.config.local.*/,
-            /.expo\/.*/,
-            /.rollup.cache\/.*/,
-        ]),
-    ];
-
-    if (config?.resolver?.blacklistRE) {
-        blacklistRE = blacklistRE.concat(config.resolver.blacklistRE);
-    }
-
     const cnfRnv: InputConfig = {
         transformer: {
             getTransformOptions: async (entryPoints, options, getDependenciesOf) => {
@@ -82,7 +64,21 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
             },
         },
         resolver: {
-            blacklistRE,
+            blockList: blocklist(
+                [
+                    /platformBuilds\/.*/,
+                    /buildHooks\/.*/,
+                    /projectConfig\/.*/,
+                    /website\/.*/,
+                    /appConfigs\/.*/,
+                    /renative.local.*/,
+                    /metro.config.local.*/,
+                    /.expo\/.*/,
+                    /.rollup.cache\/.*/,
+                ]
+                    .concat(config?.resolver?.blockList || [])
+                    .concat(config?.resolver?.blacklistRE || [])
+            ),
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
         },
         watchFolders,

--- a/packages/engine-rn-macos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-macos/src/adapters/metroAdapter.ts
@@ -1,5 +1,5 @@
 import { Env } from '@rnv/core';
-import { InputConfig } from '@rnv/sdk-react-native';
+import { withMetroConfig, mergeConfig, InputConfig } from '@rnv/sdk-react-native';
 
 const path = require('path');
 
@@ -29,12 +29,14 @@ function blacklist(additionalBlacklist: RegExp[]) {
 }
 
 export const withRNVMetro = (config: InputConfig): InputConfig => {
-    const projectPath = process.env.RNV_PROJECT_ROOT || process.cwd();
+    const projectPath = env.RNV_PROJECT_ROOT || process.cwd();
+
+    const defaultConfig = withMetroConfig(projectPath);
 
     const watchFolders = [path.resolve(projectPath, 'node_modules')];
 
     if (env.RNV_IS_MONOREPO === 'true' || env.RNV_IS_MONOREPO === true) {
-        const monoRootPath = process.env.RNV_MONO_ROOT || projectPath;
+        const monoRootPath = env.RNV_MONO_ROOT || projectPath;
         watchFolders.push(path.resolve(monoRootPath, 'node_modules'));
         watchFolders.push(path.resolve(monoRootPath, 'packages'));
     }
@@ -44,37 +46,50 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
 
     const exts: string = env.RNV_EXTENSIONS || '';
 
-    const cnf = {
-        ...config,
+    let blacklistRE = [
+        blacklist([
+            /platformBuilds\/.*/,
+            /buildHooks\/.*/,
+            /projectConfig\/.*/,
+            /website\/.*/,
+            /appConfigs\/.*/,
+            /renative.local.*/,
+            /metro.config.local.*/,
+            /.expo\/.*/,
+            /.rollup.cache\/.*/,
+        ]),
+    ];
+
+    if (config?.resolver?.blacklistRE) {
+        blacklistRE = blacklistRE.concat(config.resolver.blacklistRE);
+    }
+
+    const cnfRnv: InputConfig = {
         transformer: {
-            getTransformOptions: async () => ({
-                transform: {
-                    experimentalImportSupport: false,
-                    // this defeats the RCTDeviceEventEmitter is not a registered callable module
-                    inlineRequires: true,
-                },
-            }),
-            ...(config?.transformer || {}),
+            getTransformOptions: async (entryPoints, options, getDependenciesOf) => {
+                const transformOptions =
+                    (await config?.transformer?.getTransformOptions?.(entryPoints, options, getDependenciesOf)) || {};
+
+                return {
+                    ...transformOptions,
+                    transform: {
+                        experimentalImportSupport: false,
+                        // this defeats the RCTDeviceEventEmitter is not a registered callable module
+                        inlineRequires: true,
+                        ...(transformOptions?.transform || {}),
+                    },
+                };
+            },
         },
         resolver: {
-            blacklistRE: blacklist([
-                /platformBuilds\/.*/,
-                /buildHooks\/.*/,
-                /projectConfig\/.*/,
-                /website\/.*/,
-                /appConfigs\/.*/,
-                /renative.local.*/,
-                /metro.config.local.*/,
-                /.expo\/.*/,
-                /.rollup.cache\/.*/,
-            ]),
-            ...(config?.resolver || {}),
+            blacklistRE,
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
-            extraNodeModules: config?.resolver?.extraNodeModules,
         },
         watchFolders,
-        projectRoot: path.resolve(projectPath),
+        projectRoot: config?.projectRoot || path.resolve(projectPath),
     };
+
+    const cnf = mergeConfig(defaultConfig, config, cnfRnv);
 
     return cnf;
 };

--- a/packages/engine-rn-macos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-macos/src/adapters/metroAdapter.ts
@@ -3,7 +3,7 @@ import { withMetroConfig, mergeConfig, InputConfig } from '@rnv/sdk-react-native
 
 const path = require('path');
 
-const sharedBlacklist = [
+const sharedExclusions = [
     /node_modules\/react\/dist\/.*/,
     /website\/node_modules\/.*/,
     /heapCapture\/bundle\.js/,
@@ -21,11 +21,11 @@ function escapeRegExp(pattern: RegExp | string) {
     } else if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
         return pattern.source.replace(/\//g, path.sep);
     }
-    throw new Error(`Unexpected blacklist pattern: ${pattern}`);
+    throw new Error(`Unexpected exclusion pattern: ${pattern}`);
 }
 
-function blocklist(additionalBlacklist: RegExp[]) {
-    return [...additionalBlacklist, ...sharedBlacklist].map((regexp) => new RegExp(escapeRegExp(regexp)));
+function exclusionList(additionalExclusions: RegExp[]) {
+    return [...additionalExclusions, ...sharedExclusions].map((regexp) => new RegExp(escapeRegExp(regexp)));
 }
 
 export const withRNVMetro = (config: InputConfig): InputConfig => {
@@ -64,7 +64,7 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
             },
         },
         resolver: {
-            blockList: blocklist(
+            blockList: exclusionList(
                 [
                     /platformBuilds\/.*/,
                     /buildHooks\/.*/,

--- a/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
@@ -124,6 +124,7 @@ export const withRNVMetro = (config: InputConfig) => {
                     .concat(config?.resolver?.blockList || [])
                     .concat(config?.resolver?.blacklistRE || [])
             ),
+            blacklistRE: undefined, // must be reset to prevent it from being processed by metro
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
         },
         watchFolders,

--- a/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-tvos/src/adapters/metroAdapter.ts
@@ -5,7 +5,7 @@ const path = require('path');
 const os = require('os');
 const { doResolve } = require('@rnv/core');
 
-const sharedBlacklist = [
+const sharedExclusions = [
     /node_modules\/react\/dist\/.*/,
     /website\/node_modules\/.*/,
     /heapCapture\/bundle\.js/,
@@ -23,11 +23,11 @@ function escapeRegExp(pattern: RegExp | string) {
     } else if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
         return pattern.source.replace(/\//g, path.sep);
     }
-    throw new Error(`Unexpected blacklist pattern: ${pattern}`);
+    throw new Error(`Unexpected exclusion pattern: ${pattern}`);
 }
 
-function blocklist(additionalBlacklist: RegExp[]) {
-    return [...additionalBlacklist, ...sharedBlacklist].map((regexp) => new RegExp(escapeRegExp(regexp)));
+function exclusionList(additionalExclusions: RegExp[]) {
+    return [...additionalExclusions, ...sharedExclusions].map((regexp) => new RegExp(escapeRegExp(regexp)));
 }
 
 export const withRNVMetro = (config: InputConfig) => {
@@ -109,7 +109,7 @@ export const withRNVMetro = (config: InputConfig) => {
                 // Optionally, chain to the standard Metro resolver.
                 return context.resolveRequest(context, moduleName, platform);
             },
-            blockList: blocklist(
+            blockList: exclusionList(
                 [
                     /platformBuilds\/.*/,
                     /buildHooks\/.*/,

--- a/packages/engine-rn-windows/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-windows/src/adapters/metroAdapter.ts
@@ -25,8 +25,8 @@ function escapeRegExp(pattern: RegExp | string) {
     throw new Error(`Unexpected blacklist pattern: ${pattern}`);
 }
 
-function blacklist(additionalBlacklist: RegExp[]) {
-    return new RegExp(`(${(additionalBlacklist || []).concat(sharedBlacklist).map(escapeRegExp).join('|')})$`);
+function blocklist(additionalBlacklist: RegExp[]) {
+    return [...additionalBlacklist, ...sharedBlacklist].map((regexp) => new RegExp(escapeRegExp(regexp)));
 }
 
 export const withRNVMetro = (config: InputConfig): InputConfig => {
@@ -49,24 +49,6 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
 
     const exts: string = env.RNV_EXTENSIONS || '';
 
-    let blacklistRE = [
-        blacklist([
-            /platformBuilds\/.*/,
-            /buildHooks\/.*/,
-            /projectConfig\/.*/,
-            /website\/.*/,
-            /appConfigs\/.*/,
-            /renative.local.*/,
-            /metro.config.local.*/,
-            /.expo\/.*/,
-            /.rollup.cache\/.*/,
-        ]),
-    ];
-
-    if (config?.resolver?.blacklistRE) {
-        blacklistRE = blacklistRE.concat(config.resolver.blacklistRE);
-    }
-
     const cnfRnv: InputConfig = {
         transformer: {
             getTransformOptions: async (entryPoints, options, getDependenciesOf) => {
@@ -85,7 +67,21 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
             },
         },
         resolver: {
-            blacklistRE,
+            blockList: blocklist(
+                [
+                    /platformBuilds\/.*/,
+                    /buildHooks\/.*/,
+                    /projectConfig\/.*/,
+                    /website\/.*/,
+                    /appConfigs\/.*/,
+                    /renative.local.*/,
+                    /metro.config.local.*/,
+                    /.expo\/.*/,
+                    /.rollup.cache\/.*/,
+                ]
+                    .concat(config?.resolver?.blockList || [])
+                    .concat(config?.resolver?.blacklistRE || [])
+            ),
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
             extraNodeModules: {
                 ...(config?.resolver?.extraNodeModules || {}),

--- a/packages/engine-rn-windows/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-windows/src/adapters/metroAdapter.ts
@@ -4,7 +4,7 @@ import { withMetroConfig, mergeConfig, InputConfig } from '@rnv/sdk-react-native
 
 const path = require('path');
 
-const sharedBlacklist = [
+const sharedExclusions = [
     /node_modules\/react\/dist\/.*/,
     /website\/node_modules\/.*/,
     /heapCapture\/bundle\.js/,
@@ -22,11 +22,11 @@ function escapeRegExp(pattern: RegExp | string) {
     } else if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
         return pattern.source.replace(/\//g, path.sep);
     }
-    throw new Error(`Unexpected blacklist pattern: ${pattern}`);
+    throw new Error(`Unexpected exclusion pattern: ${pattern}`);
 }
 
-function blocklist(additionalBlacklist: RegExp[]) {
-    return [...additionalBlacklist, ...sharedBlacklist].map((regexp) => new RegExp(escapeRegExp(regexp)));
+function exclusionList(additionalExclusions: RegExp[]) {
+    return [...additionalExclusions, ...sharedExclusions].map((regexp) => new RegExp(escapeRegExp(regexp)));
 }
 
 export const withRNVMetro = (config: InputConfig): InputConfig => {
@@ -67,7 +67,7 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
             },
         },
         resolver: {
-            blockList: blocklist(
+            blockList: exclusionList(
                 [
                     /platformBuilds\/.*/,
                     /buildHooks\/.*/,

--- a/packages/engine-rn-windows/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn-windows/src/adapters/metroAdapter.ts
@@ -82,6 +82,7 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
                     .concat(config?.resolver?.blockList || [])
                     .concat(config?.resolver?.blacklistRE || [])
             ),
+            blacklistRE: undefined, // must be reset to prevent it from being processed by metro
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
             extraNodeModules: {
                 ...(config?.resolver?.extraNodeModules || {}),

--- a/packages/engine-rn/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn/src/adapters/metroAdapter.ts
@@ -25,8 +25,8 @@ function escapeRegExp(pattern: RegExp | string) {
     throw new Error(`Unexpected blacklist pattern: ${pattern}`);
 }
 
-function blacklist(additionalBlacklist: RegExp[]) {
-    return new RegExp(`(${(additionalBlacklist || []).concat(sharedBlacklist).map(escapeRegExp).join('|')})$`);
+function blocklist(additionalBlacklist: RegExp[]) {
+    return [...additionalBlacklist, ...sharedBlacklist].map((regexp) => new RegExp(escapeRegExp(regexp)));
 }
 
 export const withRNVMetro = (config: InputConfig): InputConfig => {
@@ -47,24 +47,6 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
 
     const exts: string = env.RNV_EXTENSIONS || '';
 
-    let blacklistRE = [
-        blacklist([
-            /platformBuilds\/.*/,
-            /buildHooks\/.*/,
-            /projectConfig\/.*/,
-            /website\/.*/,
-            /appConfigs\/.*/,
-            /renative.local.*/,
-            /metro.config.local.*/,
-            /.expo\/.*/,
-            /.rollup.cache\/.*/,
-        ]),
-    ];
-
-    if (config?.resolver?.blacklistRE) {
-        blacklistRE = blacklistRE.concat(config.resolver.blacklistRE);
-    }
-
     const cnfRnv: InputConfig = {
         transformer: {
             getTransformOptions: async (entryPoints, options, getDependenciesOf) => {
@@ -83,7 +65,21 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
             },
         },
         resolver: {
-            blacklistRE,
+            blockList: blocklist(
+                [
+                    /platformBuilds\/.*/,
+                    /buildHooks\/.*/,
+                    /projectConfig\/.*/,
+                    /website\/.*/,
+                    /appConfigs\/.*/,
+                    /renative.local.*/,
+                    /metro.config.local.*/,
+                    /.expo\/.*/,
+                    /.rollup.cache\/.*/,
+                ]
+                    .concat(config?.resolver?.blockList || [])
+                    .concat(config?.resolver?.blacklistRE || [])
+            ),
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
         },
         watchFolders,

--- a/packages/engine-rn/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn/src/adapters/metroAdapter.ts
@@ -4,7 +4,7 @@ import { withMetroConfig, mergeConfig, InputConfig } from '@rnv/sdk-react-native
 // TODO merge with packages/engine-rn-macos/src/adapters/metroAdapter.ts and place in @rnv/sdk-react-native
 const path = require('path');
 
-const sharedBlacklist = [
+const sharedExclusions = [
     /node_modules\/react\/dist\/.*/,
     /website\/node_modules\/.*/,
     /heapCapture\/bundle\.js/,
@@ -22,11 +22,11 @@ function escapeRegExp(pattern: RegExp | string) {
     } else if (Object.prototype.toString.call(pattern) === '[object RegExp]') {
         return pattern.source.replace(/\//g, path.sep);
     }
-    throw new Error(`Unexpected blacklist pattern: ${pattern}`);
+    throw new Error(`Unexpected exclusion pattern: ${pattern}`);
 }
 
-function blocklist(additionalBlacklist: RegExp[]) {
-    return [...additionalBlacklist, ...sharedBlacklist].map((regexp) => new RegExp(escapeRegExp(regexp)));
+function exclusionList(additionalExclusions: RegExp[]) {
+    return [...additionalExclusions, ...sharedExclusions].map((regexp) => new RegExp(escapeRegExp(regexp)));
 }
 
 export const withRNVMetro = (config: InputConfig): InputConfig => {
@@ -65,7 +65,7 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
             },
         },
         resolver: {
-            blockList: blocklist(
+            blockList: exclusionList(
                 [
                     /platformBuilds\/.*/,
                     /buildHooks\/.*/,

--- a/packages/engine-rn/src/adapters/metroAdapter.ts
+++ b/packages/engine-rn/src/adapters/metroAdapter.ts
@@ -80,6 +80,7 @@ export const withRNVMetro = (config: InputConfig): InputConfig => {
                     .concat(config?.resolver?.blockList || [])
                     .concat(config?.resolver?.blacklistRE || [])
             ),
+            blacklistRE: undefined, // must be reset to prevent it from being processed by metro
             sourceExts: [...(config?.resolver?.sourceExts || []), ...exts.split(',')],
         },
         watchFolders,

--- a/packages/sdk-react-native/src/adapters.ts
+++ b/packages/sdk-react-native/src/adapters.ts
@@ -128,7 +128,7 @@ export const withMetroConfig = (projectRoot: string): ConfigT => {
         ].join('|')
     );
 
-    const config = {
+    const config: InputConfig = {
         resolver: {
             resolverMainFields: ['react-native', 'browser', 'main'],
             platforms: ['android', 'ios'],
@@ -179,7 +179,7 @@ export const withMetroConfig = (projectRoot: string): ConfigT => {
     return mergeConfig(getDefaultConfig.getDefaultValues(projectRoot), config);
 };
 
-export const mergeConfig = (config1: ConfigT, config2: InputConfig) => {
+export const mergeConfig = (defaultConfig: ConfigT, ...configs: InputConfig[]): ConfigT => {
     const mc = require('metro-config');
-    return mc.mergeConfig(config1, config2);
+    return mc.mergeConfig(defaultConfig, ...configs);
 };


### PR DESCRIPTION
## Description

There are problems with merging metro configs (some properties are overwritten).

For example:
```javascript
module.exports = withRNVMetro({
    resolver: {
        sourceExts: ['svg'],
    }
})
``` 
as a result, the merged config contains only the custom sourceExts array, losing all rnv extensions (although initially, the logic implied unifying some of the properties).

This PR fixes such errors and improves the config merge flow.

## Related issues

- GH issues

## Npm releases

n/a
