### PR TITLE
fix override when the original and the override have overlapping subs…

### DIFF
--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -830,9 +830,26 @@ export const overrideFileContents = (
                     )}. FIXING...DONE`
                 );
             } else if (overrideExists) {
-                logInfo(
-                    `${chalk().gray(dest)} overridden by: ${chalk().gray(overridePath.split('node_modules').pop())}`
-                );
+                if (originalExists) {
+                    if (fk.includes(override[fk])) {
+                        fileToFix = fileToFix.replace(originalRegEx, `${override[fk]}`);
+                        logSuccess(
+                            `${chalk().bold.white(dest)} requires override by: ${chalk().bold.white(
+                                overridePath.split('node_modules').pop()
+                            )}. FIXING...DONE`
+                        );
+                    } else {
+                        logInfo(
+                            `${chalk().gray(dest)} overridden by: ${chalk().gray(
+                                overridePath.split('node_modules').pop()
+                            )}`
+                        );
+                    }
+                } else {
+                    logInfo(
+                        `${chalk().gray(dest)} overridden by: ${chalk().gray(overridePath.split('node_modules').pop())}`
+                    );
+                }
             } else {
                 failTerms.push(fk);
             }


### PR DESCRIPTION
## Description

- chore/cherry-pick fix override when the original and the override have overlapping substrings

## Related issues

- GH issues

## Npm releases

n/a
