### PR TITLE
fix/reset_overrides_on_bootstrap

### DIFF
--- a/buildHooks/src/index.ts
+++ b/buildHooks/src/index.ts
@@ -1,6 +1,6 @@
 import { comparePluginTemplates } from './comparePluginTemplates';
 import { comparePluginOverrides } from './comparePluginOverrides';
-
+import { resetOverrides } from './resetOverrides';
 import { prePublish } from './prePublish';
 import { gitCommit, gitCommitAndTag, gitTag } from '@rnv/build-hooks-git';
 import { generateSchema } from '@rnv/build-hooks-schema';
@@ -13,6 +13,7 @@ const hooks = {
     gitCommit,
     gitTag,
     generateSchema,
+    resetOverrides,
 };
 
 const pipes = {};

--- a/buildHooks/src/resetOverrides.ts
+++ b/buildHooks/src/resetOverrides.ts
@@ -1,0 +1,45 @@
+// npx rnv hooks run -x resetOverrides
+import {
+    RnvFileName,
+    fsExistsSync,
+    fsReadFileSync,
+    logSuccess,
+    removeDirSync,
+    revertOverrideToOriginal,
+} from '@rnv/core';
+import path from 'path';
+
+export const resetOverrides = async () => {
+    const overrideDir = path.join(process.cwd(), '.rnv', 'overrides');
+
+    const appliedOverrideFilePath = path.join(overrideDir, RnvFileName.appliedOverride);
+
+    if (fsExistsSync(appliedOverrideFilePath)) {
+        const appliedOverrides = JSON.parse(fsReadFileSync(appliedOverrideFilePath).toString());
+
+        Object.keys(appliedOverrides).forEach((moduleName) => {
+            const appliedVersion = appliedOverrides[moduleName].version;
+            const packageJsonPath = path.join(process.cwd(), 'node_modules', moduleName, RnvFileName.package);
+
+            if (fsExistsSync(packageJsonPath)) {
+                const packageContent = JSON.parse(fsReadFileSync(packageJsonPath).toString());
+                const currentVersion = packageContent.version;
+
+                if (currentVersion === appliedVersion) {
+                    const packageOverrides = appliedOverrides[moduleName];
+                    Object.keys(packageOverrides).forEach((filePath) => {
+                        if (filePath !== 'version') {
+                            const backupPath = path.join(overrideDir, moduleName, filePath);
+                            const destinationPath = path.join(process.cwd(), 'node_modules', moduleName, filePath);
+
+                            revertOverrideToOriginal(destinationPath, backupPath);
+                        }
+                    });
+                }
+            }
+        });
+        removeDirSync(overrideDir);
+        return logSuccess('Plugin overrides have been reverted successfully');
+    }
+    return logSuccess(`Plugin overrides have not been applied yet`);
+};

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "url": "git://github.com/flexn-io/renative.git"
     },
     "scripts": {
-        "bootstrap": "npx lerna@6 bootstrap && yarn build && yarn link:rnv && yarn generateSchema",
+        "bootstrap": "npx lerna@6 bootstrap && yarn build && yarn link:rnv && yarn generateSchema && yarn resetOverrides",
         "bootstrap-clean": "yarn clean-gitignore && yarn bootstrap",
         "build": "lerna run build",
         "clean-gitignore": "git clean -f -d -i -X",
@@ -66,9 +66,10 @@
         "deploy:next": "yarn pre-publish && npx lerna publish from-package --dist-tag next && git push --tags origin HEAD",
         "deploy:prod": "yarn pre-publish && npx lerna publish from-package && git push --tags origin HEAD",
         "generateSchema": "npx rnv hooks run -x generateSchema",
+        "resetOverrides": "npx rnv hooks run -x resetOverrides",
         "link:rnv": "npm r rnv -g && cd packages/rnv && npm link",
         "lint": "npx eslint ./packages",
-        "postinstall": "npx lerna link --force-local && npx jetify && npx husky install ",
+        "postinstall": "npx lerna link --force-local && npx jetify && npx husky install",
         "pre-publish": "yarn build && yarn link:rnv && yarn lint && yarn test && rnv hooks run -x prePublish && rnv hooks run -x gitCommitAndTag && yarn generateSchema",
         "prettier-write-all": "npx prettier '**/*.{js,jsx,ts,tsx,mjs,cjs,json,md}' --write --config .prettierrc.js",
         "prettier-write-json": "npx prettier '**/{package.json,renative.plugins.json,renative.json,renative.templates.json,renative.template.json,renative.plugin.json,renative.engine.json,rnv.json}' --write --config .prettierrc.js",


### PR DESCRIPTION
## Description

- `yarn bootstrap` doesn’t revert overridden files to their original state after execution

## Related issues

- GH issues

## Npm releases

n/a

## Testing.

-  yarn bootstrap => the `.rnv/overrides` folder should be removed and patched packages should be reverted to their original state
-  alternative way:  yarn resetOverrides ( npx rnv hooks run -x resetOverrides )

