### PR TITLE
fix/overrides_when_version_changes + add --skipOverridesCheck

### DIFF
--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -832,6 +832,7 @@ export const overrideFileContents = (
             } else if (overrideExists) {
                 if (originalExists) {
                     if (fk.includes(override[fk])) {
+                        foundRegEx = true;
                         fileToFix = fileToFix.replace(originalRegEx, `${override[fk]}`);
                         logSuccess(
                             `${chalk().bold.white(dest)} requires override by: ${chalk().bold.white(
@@ -875,6 +876,8 @@ export const overrideFileContents = (
             appliedOverrides[packageName].version = packageVersion;
             fsWriteFileSync(dest, fileToFix);
             _writeAppliedOverrides(appliedOverrides, appliedOverrideFilePath);
+        } else if (foundRegEx) {
+            fsWriteFileSync(dest, fileToFix);
         }
     } else {
         logDebug(`overrideFileContents Warning: path does not exist ${dest}`);

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -1098,7 +1098,11 @@ export const overrideTemplatePlugins = async () => {
     logDefault('overrideTemplatePlugins');
 
     const c = getContext();
-
+    const { skipOverridesCheck } = c.program.opts();
+    if (skipOverridesCheck) {
+        logInfo(`Plugin overrides will not be applied because --skipOverridesCheck parameter was passed.`);
+        return true;
+    }
     const rnvPluginsDirs = c.paths.scopedConfigTemplates.pluginTemplatesDirs;
     const appPluginDirs = c.paths.appConfig.pluginDirs;
 

--- a/packages/core/src/tasks/taskOptions.ts
+++ b/packages/core/src/tasks/taskOptions.ts
@@ -100,6 +100,12 @@ export const RnvTaskOptions = createTaskOptionsMap([
         description: 'Skips auto update of npm dependencies if mismatch found',
     },
     {
+        key: 'skip-overrides-check',
+        altKey: 'skipOverridesCheck',
+        description:
+            'Skips applying plugin overrides. Useful for avoiding unnecessary checks on every run when overrides are already applied.',
+    },
+    {
         key: 'offline',
         description: 'Run without connecting to the internet whenever possible',
     },
@@ -238,6 +244,7 @@ export const RnvTaskCoreOptionPresets = createTaskOptionsPreset({
         RnvTaskOptions.noIntro,
         RnvTaskOptions.offline,
         RnvTaskOptions.skipDependencyCheck,
+        RnvTaskOptions.skipOverridesCheck,
     ],
 });
 

--- a/packages/template-starter/scripts/postinstall.js
+++ b/packages/template-starter/scripts/postinstall.js
@@ -11,6 +11,7 @@ const {
     logError,
     RnvFileName,
     fsExistsSync,
+    fsMkdirSync,
     fsReadFileSync,
     removeDirSync,
     revertOverrideToOriginal,
@@ -40,7 +41,11 @@ const RNV_HOME_DIR = path.join(__dirname, '..');
 })();
 
 const resetOverrides = async () => {
-    const overrideDir = path.join(process.cwd(), '.rnv', 'overrides');
+    const rnvFolder = path.join(process.cwd(), '.rnv');
+    if (!fsExistsSync(rnvFolder)) {
+        fsMkdirSync(rnvFolder);
+    }
+    const overrideDir = path.join(rnvFolder, 'overrides');
 
     const appliedOverrideFilePath = path.join(overrideDir, RnvFileName.appliedOverride);
 


### PR DESCRIPTION
## Description

-  the functionality of applying overrides does not work correctly when changing the version of rnv
- postinstall script tries to use non-existent `.rnv` folder => yarn execution fails with error in a cloned renative project:

```
[4/4] 🔨  Building fresh packages...
$ node scripts/postinstall.js
error: ⨯  Error: ENOENT: no such file or directory, mkdir '/Users/pauliusguzas/Desktop/random_testai/hello-renative/.rnv/overrides'
    at Object.mkdirSync (node:fs:1398:3)
    at fsMkdirSync (/Users/pauliusguzas/Desktop/random_testai/hello-renative/node_modules/@rnv/core/src/system/fs.ts:56:66)
    at _ensureOverrideDirExists (/Users/pauliusguzas/Desktop/random_testai/hello-renative/node_modules/@rnv/core/src/plugins/index.ts:981:20)
    at overrideFileContents (/Users/pauliusguzas/Desktop/random_testai/hello-renative/node_modules/@rnv/core/src/plugins/index.ts:793:25)
    at /Users/pauliusguzas/Desktop/random_testai/hello-renative/node_modules/@rnv/core/src/plugins/index.ts:751:45
    at Array.forEach (<anonymous>)
    at /Users/pauliusguzas/Desktop/random_testai/hello-renative/node_modules/@rnv/core/src/plugins/index.ts:743:36
    at Array.forEach (<anonymous>)
    at _overridePlugin (/Users/pauliusguzas/Desktop/random_testai/hello-renative/node_modules/@rnv/core/src/plugins/index.ts:690:22)
    at /Users/pauliusguzas/Desktop/random_testai/hello-renative/node_modules/@rnv/core/src/plugins/index.ts:1108:25
```
- add  `--skipOverridesCheck`  option   to skip applying plugin overrides. Useful for avoiding unnecessary checks on every run   when overrides are already applied.

## Related issues

- https://github.com/flexn-io/renative/pull/1796

## Npm releases

n/a
