### PR TITLE
fix/deployment_target_tvos

### DIFF
--- a/packages/sdk-apple/src/xcodeParser.ts
+++ b/packages/sdk-apple/src/xcodeParser.ts
@@ -130,7 +130,9 @@ const _parseXcodeProject = (c: Context, platform: RnvPlatform) =>
             if (platform === 'ios') {
                 xcodeProj.updateBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', deploymentTarget);
             }
-
+            if (platform === 'tvos') {
+                xcodeProj.updateBuildProperty('TVOS_DEPLOYMENT_TARGET', deploymentTarget);
+            }
             if (provisionProfileSpecifier) {
                 xcodeProj.updateBuildProperty('PROVISIONING_PROFILE_SPECIFIER', `"${provisionProfileSpecifier}"`);
             }


### PR DESCRIPTION
## Description

- [tvOS] deploymentTarget in renative.json isn't being applied 

## Related issues

- https://github.com/flexn-io/renative/issues/1799

## Npm releases

n/a
