### PR TITLE
fix/appConfigID_option_apple-based_platforms

### DIFF
--- a/packages/sdk-apple/src/tasks/taskBuild.ts
+++ b/packages/sdk-apple/src/tasks/taskBuild.ts
@@ -1,4 +1,4 @@
-import { createTask, RnvTaskName } from '@rnv/core';
+import { createTask, RnvTaskName, RnvTaskOptions } from '@rnv/core';
 import { buildXcodeProject } from '../runner';
 import { SdkPlatforms } from '../common';
 import { TaskOptionPresets, TaskOptions } from '../taskOptions';
@@ -14,6 +14,6 @@ export default createTask({
         return buildXcodeProject();
     },
     task: RnvTaskName.build,
-    options: TaskOptionPresets.withConfigure([TaskOptions.xcodebuildArgs]),
+    options: [...TaskOptionPresets.withConfigure([TaskOptions.xcodebuildArgs]), RnvTaskOptions.appConfigID],
     platforms: SdkPlatforms,
 });

--- a/packages/sdk-apple/src/tasks/taskExport.ts
+++ b/packages/sdk-apple/src/tasks/taskExport.ts
@@ -1,7 +1,7 @@
-import { createTask, RnvTaskName } from '@rnv/core';
+import { createTask, RnvTaskName, RnvTaskOptions } from '@rnv/core';
 import { exportXcodeProject } from '../runner';
 import { SdkPlatforms } from '../common';
-import { TaskOptionPresets } from '../taskOptions';
+import { TaskOptionPresets, TaskOptions } from '../taskOptions';
 
 export default createTask({
     description: 'Export the app into deployable binary',
@@ -10,6 +10,6 @@ export default createTask({
         return exportXcodeProject();
     },
     task: RnvTaskName.export,
-    options: TaskOptionPresets.withConfigure(),
+    options: [...TaskOptionPresets.withConfigure([TaskOptions.xcodebuildExportArgs]), RnvTaskOptions.appConfigID],
     platforms: SdkPlatforms,
 });


### PR DESCRIPTION
## Description

- [ios, tvos] Build and export commands ignore what is given in -c argument in cli

## Related issues

- https://github.com/flexn-io/renative/issues/1810

## Npm releases

n/a
