### PR TITLE
Fix typo in taskOptions.ts file description

### DIFF
--- a/packages/core/src/tasks/taskOptions.ts
+++ b/packages/core/src/tasks/taskOptions.ts
@@ -193,7 +193,7 @@ export const RnvTaskOptions = createTaskOptionsMap([
     },
     {
         key: 'hosted',
-        description: 'Run in a hosted environment (skip budleAssets)',
+        description: 'Run in a hosted environment (skip bundleAssets)',
     },
     {
         key: 'device',


### PR DESCRIPTION
## Description

-  Fix typo in taskOptions.ts file description"budleAssets" to "bundleAssets"