### PR TITLE
Fix regression for failing to run for the first time

### DIFF
--- a/packages/core/src/projects/update.ts
+++ b/packages/core/src/projects/update.ts
@@ -22,7 +22,7 @@ export const checkAndUpdateProjectIfRequired = async () => {
 
     if (!platform) return;
     const { isMonorepo } = c.buildConfig;
-    if (isMonorepo) return true;
+    if (isMonorepo || typeof platform === 'boolean') return true;
     await applyTemplate();
 
     const allPlatforms = Object.keys(c.buildConfig?.platforms || {});


### PR DESCRIPTION
## Description

- This fixes the issue where npx rnv run -p could not be executed without specifying a platform.

## Related issues

- (cherry picked from commit 46ff90fecf7c0c77dcb3f33e639efb2208b985d8)

## Npm releases

n/a
