### PR TITLE
chore: update @react-native-async-storage/async-storage to 1.24.0

### DIFF
--- a/packages/config-templates/renative.templates.json
+++ b/packages/config-templates/renative.templates.json
@@ -342,7 +342,7 @@
             "tvos": {
                 "podName": "RNCAsyncStorage"
             },
-            "version": "1.17.10",
+            "version": "1.24.0",
             "webpackConfig": {
                 "modulePaths": true
             }


### PR DESCRIPTION
## Description

- Small package update needed for the project. Latest is 2.1.1, but there were some major changes, so to avoid any issues for now, updating to latest v1 version available would be good.

