### PR TITLE
feat: prepare @react-native-community/blur for RN 0.77+

### DIFF
--- a/packages/config-templates/renative.templates.json
+++ b/packages/config-templates/renative.templates.json
@@ -398,17 +398,17 @@
         },
         "@react-native-community/blur": {
             "android": {
-                "package": "com.cmcewen.blurview.BlurViewPackage",
+                "package": "com.reactnativecommunity.blurview.BlurViewPackage",
                 "path": "{{PLUGIN_ROOT}}/android",
                 "projectName": "react-native-community-blur"
             },
             "androidtv": {
-                "package": "com.cmcewen.blurview.BlurViewPackage",
+                "package": "com.reactnativecommunity.blurview.BlurViewPackage",
                 "path": "{{PLUGIN_ROOT}}/android",
                 "projectName": "react-native-community-blur"
             },
             "firetv": {
-                "package": "com.cmcewen.blurview.BlurViewPackage",
+                "package": "com.reactnativecommunity.blurview.BlurViewPackage",
                 "path": "{{PLUGIN_ROOT}}/android",
                 "projectName": "react-native-community-blur"
             },
@@ -420,7 +420,7 @@
                 "path": "{{PLUGIN_ROOT}}",
                 "podName": "react-native-blur"
             },
-            "version": "4.3.0",
+            "version": "4.4.1",
             "web": null
         },
         "@react-native-community/cameraroll": {


### PR DESCRIPTION
## Description
Update @react-native-community/blur and change the java package name to the one on the newer versions
Pick a version compatible with RN 0.77+

## Related issues

- GH issues

## Npm releases

n/a
